### PR TITLE
fix: reject unsupported locales and return 404 instead of fallback

### DIFF
--- a/apps/web/drizzle/0001_abandoned_blacklash.sql
+++ b/apps/web/drizzle/0001_abandoned_blacklash.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "topic_posts" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"topic_type" varchar(50) NOT NULL,
+	"topic_key" varchar(50) NOT NULL,
+	"parent_id" uuid,
+	"content" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "idx_topic_posts_topic" ON "topic_posts" USING btree ("topic_type","topic_key");--> statement-breakpoint
+CREATE INDEX "idx_topic_posts_user" ON "topic_posts" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "idx_topic_posts_parent" ON "topic_posts" USING btree ("parent_id");

--- a/apps/web/drizzle/meta/0001_snapshot.json
+++ b/apps/web/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,850 @@
+{
+  "id": "bfd66d8a-6795-4514-9d60-462c7fb31e3d",
+  "prevId": "a21170cc-c3f5-4283-a4a7-91f5d50ec778",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.glossary_term_aliases": {
+      "name": "glossary_term_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "term_id": {
+          "name": "term_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "glossary_term_aliases_term_id_glossary_terms_id_fk": {
+          "name": "glossary_term_aliases_term_id_glossary_terms_id_fk",
+          "tableFrom": "glossary_term_aliases",
+          "tableTo": "glossary_terms",
+          "columnsFrom": ["term_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.glossary_term_positions": {
+      "name": "glossary_term_positions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "term_id": {
+          "name": "term_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fen": {
+          "name": "fen",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "caption": {
+          "name": "caption",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "glossary_term_positions_term_id_glossary_terms_id_fk": {
+          "name": "glossary_term_positions_term_id_glossary_terms_id_fk",
+          "tableFrom": "glossary_term_positions",
+          "tableTo": "glossary_terms",
+          "columnsFrom": ["term_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.glossary_term_relations": {
+      "name": "glossary_term_relations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "term_id": {
+          "name": "term_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_term_id": {
+          "name": "related_term_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "glossary_term_relations_term_id_glossary_terms_id_fk": {
+          "name": "glossary_term_relations_term_id_glossary_terms_id_fk",
+          "tableFrom": "glossary_term_relations",
+          "tableTo": "glossary_terms",
+          "columnsFrom": ["term_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "glossary_term_relations_related_term_id_glossary_terms_id_fk": {
+          "name": "glossary_term_relations_related_term_id_glossary_terms_id_fk",
+          "tableFrom": "glossary_term_relations",
+          "tableTo": "glossary_terms",
+          "columnsFrom": ["related_term_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_term_relation": {
+          "name": "uq_term_relation",
+          "nullsNotDistinct": false,
+          "columns": ["term_id", "related_term_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.glossary_term_translations": {
+      "name": "glossary_term_translations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "term_id": {
+          "name": "term_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "term": {
+          "name": "term",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reading": {
+          "name": "reading",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "glossary_term_translations_term_id_glossary_terms_id_fk": {
+          "name": "glossary_term_translations_term_id_glossary_terms_id_fk",
+          "tableFrom": "glossary_term_translations",
+          "tableTo": "glossary_terms",
+          "columnsFrom": ["term_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_term_locale": {
+          "name": "uq_term_locale",
+          "nullsNotDistinct": false,
+          "columns": ["term_id", "locale"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.glossary_terms": {
+      "name": "glossary_terms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "term_en": {
+          "name": "term_en",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "glossary_terms_slug_unique": {
+          "name": "glossary_terms_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'en'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "posts_category_id_categories_id_fk": {
+          "name": "posts_category_id_categories_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "categories",
+          "columnsFrom": ["category_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_sessions": {
+      "name": "practice_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "menu_type": {
+          "name": "menu_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_practice_sessions_user": {
+          "name": "idx_practice_sessions_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_practice_sessions_menu": {
+          "name": "idx_practice_sessions_menu",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "menu_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_practice_sessions_recent": {
+          "name": "idx_practice_sessions_recent",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flair": {
+          "name": "flair",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fide_id": {
+          "name": "fide_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chesscom_username": {
+          "name": "chesscom_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lichess_username": {
+          "name": "lichess_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_username_unique": {
+          "name": "profiles_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic_posts": {
+      "name": "topic_posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_type": {
+          "name": "topic_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_key": {
+          "name": "topic_key",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_topic_posts_topic": {
+          "name": "idx_topic_posts_topic",
+          "columns": [
+            {
+              "expression": "topic_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_topic_posts_user": {
+          "name": "idx_topic_posts_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_topic_posts_parent": {
+          "name": "idx_topic_posts_parent",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "app_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_user_role": {
+          "name": "uq_user_role",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "role"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.app_role": {
+      "name": "app_role",
+      "schema": "public",
+      "values": ["admin", "user"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1772753495871,
       "tag": "0000_initial",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1772832700102,
+      "tag": "0001_abandoned_blacklash",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/src/app/[locale]/(protected)/mypage/(confirmed)/profile/_components/AvatarUpload.tsx
+++ b/apps/web/src/app/[locale]/(protected)/mypage/(confirmed)/profile/_components/AvatarUpload.tsx
@@ -5,6 +5,8 @@ import { ChangeEvent, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import Image from 'next/image';
 
+import { useToast } from '@/app/[locale]/_contexts/ToastContext';
+
 type Props = {
   currentAvatarUrl: string | null;
   onUploaded: (url: string) => void;
@@ -15,6 +17,7 @@ const MAX_SIZE = 2 * 1024 * 1024; // 2MB
 
 export function AvatarUpload({ currentAvatarUrl, onUploaded }: Props) {
   const t = useTranslations('profile');
+  const { showToast } = useToast();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(currentAvatarUrl);
   const [isUploading, setIsUploading] = useState(false);
@@ -74,6 +77,7 @@ export function AvatarUpload({ currentAvatarUrl, onUploaded }: Props) {
       const { avatarUrl } = await res.json();
       setPreviewUrl(avatarUrl);
       onUploaded(avatarUrl);
+      showToast(t('avatarUploaded'), 'success');
     } catch {
       setError(t('avatarUploadFailed'));
       setPreviewUrl(currentAvatarUrl);

--- a/apps/web/src/app/[locale]/(protected)/mypage/(confirmed)/profile/_components/ProfileForm.tsx
+++ b/apps/web/src/app/[locale]/(protected)/mypage/(confirmed)/profile/_components/ProfileForm.tsx
@@ -5,6 +5,8 @@ import { FormEvent, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/navigation';
 
+import { TextInput, Textarea } from '@/app/_components';
+
 import type { Profile } from '@/lib/db';
 
 import { AvatarUpload } from './AvatarUpload';
@@ -98,9 +100,6 @@ export function ProfileForm({ locale, profile }: Props) {
     }
   };
 
-  const inputClassName =
-    'w-full px-4 py-3 bg-card border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent';
-
   const labelClassName = 'block text-sm font-medium text-foreground mb-1';
 
   return (
@@ -125,14 +124,12 @@ export function ProfileForm({ locale, profile }: Props) {
           <label htmlFor="displayName" className={labelClassName}>
             {t('displayNameLabel')} <span className="text-destructive">*</span>
           </label>
-          <input
+          <TextInput
             id="displayName"
-            type="text"
             value={displayName}
             onChange={(e) => setDisplayName(e.target.value)}
             maxLength={50}
             autoComplete="off"
-            className={inputClassName}
           />
           {error?.field === 'displayName' && (
             <p className="mt-2 text-sm text-destructive">{error.message}</p>
@@ -144,15 +141,13 @@ export function ProfileForm({ locale, profile }: Props) {
           <label htmlFor="bio" className={labelClassName}>
             {t('bioLabel')}
           </label>
-          <textarea
+          <Textarea
             id="bio"
             value={bio}
             onChange={(e) => setBio(e.target.value)}
             placeholder={t('bioPlaceholder')}
             maxLength={500}
             rows={4}
-            style={{ resize: 'vertical' }}
-            className={inputClassName}
           />
           {error?.field === 'bio' && (
             <p className="mt-2 text-sm text-destructive">{error.message}</p>
@@ -194,15 +189,13 @@ export function ProfileForm({ locale, profile }: Props) {
           <label htmlFor="fideId" className={labelClassName}>
             {t('fideIdLabel')}
           </label>
-          <input
+          <TextInput
             id="fideId"
-            type="text"
             value={fideId}
             onChange={(e) => setFideId(e.target.value)}
             placeholder={t('fideIdPlaceholder')}
             maxLength={50}
             autoComplete="off"
-            className={inputClassName}
           />
         </div>
 
@@ -210,15 +203,13 @@ export function ProfileForm({ locale, profile }: Props) {
           <label htmlFor="chesscomUsername" className={labelClassName}>
             {t('chesscomUsernameLabel')}
           </label>
-          <input
+          <TextInput
             id="chesscomUsername"
-            type="text"
             value={chesscomUsername}
             onChange={(e) => setChesscomUsername(e.target.value)}
             placeholder={t('chesscomUsernamePlaceholder')}
             maxLength={255}
             autoComplete="off"
-            className={inputClassName}
           />
         </div>
 
@@ -226,15 +217,13 @@ export function ProfileForm({ locale, profile }: Props) {
           <label htmlFor="lichessUsername" className={labelClassName}>
             {t('lichessUsernameLabel')}
           </label>
-          <input
+          <TextInput
             id="lichessUsername"
-            type="text"
             value={lichessUsername}
             onChange={(e) => setLichessUsername(e.target.value)}
             placeholder={t('lichessUsernamePlaceholder')}
             maxLength={255}
             autoComplete="off"
-            className={inputClassName}
           />
         </div>
       </section>

--- a/apps/web/src/app/[locale]/(protected)/mypage/(provisional)/setup-username/_components/UsernameForm.tsx
+++ b/apps/web/src/app/[locale]/(protected)/mypage/(provisional)/setup-username/_components/UsernameForm.tsx
@@ -5,7 +5,7 @@ import { FormEvent, useCallback, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/navigation';
 
-import { Button } from '@/app/_components';
+import { Button, TextInput } from '@/app/_components';
 
 import { validateUsername } from '@/lib/username';
 
@@ -97,16 +97,14 @@ export function UsernameForm({ locale }: Props) {
           {t('usernameLabel')} <span className="text-destructive">*</span>
         </label>
         <p className="text-xs text-muted-foreground mb-2">{t('usernameDescription')}</p>
-        <input
+        <TextInput
           id="username"
-          type="text"
           value={username}
           onChange={(e) => handleUsernameChange(e.target.value)}
           placeholder={t('usernamePlaceholder')}
           maxLength={20}
           autoFocus
           autoComplete="off"
-          className="w-full px-4 py-3 bg-card border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent"
         />
         {error && <p className="mt-2 text-sm text-destructive">{error}</p>}
         <ul className="mt-2 list-disc list-inside space-y-0.5">
@@ -121,15 +119,13 @@ export function UsernameForm({ locale }: Props) {
           {t('displayNameLabel')}
         </label>
         <p className="text-xs text-muted-foreground mb-2">{t('displayNameDescription')}</p>
-        <input
+        <TextInput
           id="displayName"
-          type="text"
           value={displayName}
           onChange={(e) => setDisplayName(e.target.value)}
           placeholder={t('displayNamePlaceholder')}
           maxLength={50}
           autoComplete="off"
-          className="w-full px-4 py-3 bg-card border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent"
         />
         <ul className="mt-2 list-disc list-inside">
           <li className="text-xs text-muted-foreground">{t('displayNameCanChange')}</li>

--- a/apps/web/src/app/[locale]/(public)/topics/page.tsx
+++ b/apps/web/src/app/[locale]/(public)/topics/page.tsx
@@ -1,0 +1,57 @@
+import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+
+import {
+  Breadcrumb,
+  CardLink,
+  Divider,
+  PageDescription,
+  PagePanel,
+  PageTitle,
+} from '@/app/[locale]/_components';
+import { generateCanonicalMetadata } from '@/app/[locale]/_lib/metadata';
+import type { Locale } from '@/app/[locale]/_lib/types';
+
+type Props = {
+  params: Promise<{ locale: Locale }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'metadata.topics' });
+
+  return {
+    ...generateCanonicalMetadata({ locale, path: 'topics' }),
+    title: t('title'),
+    description: t('description'),
+  };
+}
+
+export default async function TopicsPage({ params }: Props) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'topics' });
+
+  return (
+    <div className="space-y-8">
+      <PageTitle>{t('title')}</PageTitle>
+
+      <PageDescription>{t('description')}</PageDescription>
+
+      <PagePanel>
+        <div className="space-y-4">
+          <CardLink
+            href="/topics/squares"
+            icon="♟"
+            title={t('categories.squares.title')}
+            description={t('categories.squares.description')}
+            locale={locale}
+          />
+        </div>
+
+        <Divider />
+
+        <Breadcrumb items={[{ label: t('title') }]} locale={locale} />
+      </PagePanel>
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/(public)/topics/squares/[square]/_components/PostCard.tsx
+++ b/apps/web/src/app/[locale]/(public)/topics/squares/[square]/_components/PostCard.tsx
@@ -1,0 +1,57 @@
+import Image from 'next/image';
+import Link from 'next/link';
+
+import type { TopicPostWithAuthor } from '../../_lib/queries';
+
+type Props = {
+  post: TopicPostWithAuthor;
+  locale: string;
+  square: string;
+};
+
+export function PostCard({ post, locale, square }: Props) {
+  const displayName = post.author?.displayName || post.author?.username || 'Anonymous';
+  const contentPreview =
+    post.content.length > 200 ? post.content.slice(0, 200) + '...' : post.content;
+
+  return (
+    <Link
+      href={`/${locale}/topics/squares/${square}/posts/${post.id}`}
+      className="block p-4 rounded-md border border-border bg-card hover:border-foreground/20 transition-colors"
+    >
+      <div className="flex items-start gap-3">
+        {post.author?.avatarUrl ? (
+          <Image
+            src={post.author.avatarUrl}
+            alt={displayName}
+            width={32}
+            height={32}
+            className="rounded-full flex-shrink-0"
+          />
+        ) : (
+          <div className="w-8 h-8 rounded-full bg-muted flex items-center justify-center flex-shrink-0">
+            <span className="text-xs text-muted-foreground">
+              {displayName.charAt(0).toUpperCase()}
+            </span>
+          </div>
+        )}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground mb-1">
+            <span className="font-medium text-foreground">{displayName}</span>
+            <span>·</span>
+            <time dateTime={post.createdAt.toISOString()}>
+              {post.createdAt.toLocaleDateString(locale, {
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric',
+              })}
+            </time>
+          </div>
+          <p className="text-sm text-foreground whitespace-pre-wrap break-words">
+            {contentPreview}
+          </p>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/apps/web/src/app/[locale]/(public)/topics/squares/[square]/_components/PostCard.tsx
+++ b/apps/web/src/app/[locale]/(public)/topics/squares/[square]/_components/PostCard.tsx
@@ -1,22 +1,29 @@
-import Image from 'next/image';
-import Link from 'next/link';
+'use client';
 
-import type { TopicPostWithAuthor } from '../../_lib/queries';
+import { useTranslations } from 'next-intl';
+import Image from 'next/image';
+
+import { Link } from '@/i18n/routing';
+
+import type { PostWithReplyMeta } from '../../_lib/queries';
+import { formatRelativeTime } from '../../_lib/relative-time';
 
 type Props = {
-  post: TopicPostWithAuthor;
+  post: PostWithReplyMeta;
   locale: string;
   square: string;
 };
 
 export function PostCard({ post, locale, square }: Props) {
+  const t = useTranslations('topics.squares');
   const displayName = post.author?.displayName || post.author?.username || 'Anonymous';
   const contentPreview =
     post.content.length > 200 ? post.content.slice(0, 200) + '...' : post.content;
 
   return (
     <Link
-      href={`/${locale}/topics/squares/${square}/posts/${post.id}`}
+      href={`/topics/squares/${square}/posts/${post.id}`}
+      locale={locale}
       className="block p-4 rounded-md border border-border bg-card hover:border-foreground/20 transition-colors"
     >
       <div className="flex items-start gap-3">
@@ -52,6 +59,44 @@ export function PostCard({ post, locale, square }: Props) {
           </p>
         </div>
       </div>
+
+      {post.replyMeta.replyCount > 0 && (
+        <div className="flex items-center gap-3 mt-3 pt-3 border-t border-border">
+          <div className="flex -space-x-2">
+            {post.replyMeta.repliers.map((replier, i) =>
+              replier.avatarUrl ? (
+                <Image
+                  key={i}
+                  src={replier.avatarUrl}
+                  alt={replier.displayName}
+                  width={24}
+                  height={24}
+                  className="rounded-full border-2 border-card"
+                />
+              ) : (
+                <div
+                  key={i}
+                  className="w-6 h-6 rounded-full bg-muted border-2 border-card flex items-center justify-center"
+                >
+                  <span className="text-[10px] text-muted-foreground">
+                    {replier.displayName.charAt(0).toUpperCase()}
+                  </span>
+                </div>
+              )
+            )}
+          </div>
+          <span className="text-xs text-muted-foreground">
+            {t('replyCount', { count: post.replyMeta.replyCount })}
+          </span>
+          {post.replyMeta.latestReplyAt && (
+            <span className="text-xs text-muted-foreground ml-auto">
+              {t('newReply', {
+                time: formatRelativeTime(post.replyMeta.latestReplyAt, locale, t('justNow')),
+              })}
+            </span>
+          )}
+        </div>
+      )}
     </Link>
   );
 }

--- a/apps/web/src/app/[locale]/(public)/topics/squares/[square]/_components/SquareHighlightBoard.tsx
+++ b/apps/web/src/app/[locale]/(public)/topics/squares/[square]/_components/SquareHighlightBoard.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useCallback } from 'react';
+
+import { BoardLayout } from '@/app/_components';
+import type { SquareRenderInfo } from '@/app/_components';
+
+import { getBoardThemeColors } from '@/lib/boardThemes';
+
+import { useGamePreferences } from '@/app/[locale]/_contexts/GamePreferencesContext';
+
+type Props = {
+  square: string;
+};
+
+export function SquareHighlightBoard({ square }: Props) {
+  const { preferences } = useGamePreferences();
+  const themeColors = getBoardThemeColors(preferences.boardTheme);
+
+  const renderSquare = useCallback(() => null, []);
+
+  const squareProps = useCallback(
+    ({ square: sq }: SquareRenderInfo) => ({
+      highlightType: (sq === square ? 'last-move' : 'none') as 'last-move' | 'none',
+    }),
+    [square]
+  );
+
+  return (
+    <div className="max-w-xs mx-auto">
+      <BoardLayout
+        showCoordinates={preferences.showCoordinates}
+        themeColors={themeColors}
+        renderSquare={renderSquare}
+        squareProps={squareProps}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/(public)/topics/squares/[square]/_components/index.ts
+++ b/apps/web/src/app/[locale]/(public)/topics/squares/[square]/_components/index.ts
@@ -1,0 +1,2 @@
+export { PostCard } from './PostCard';
+export { SquareHighlightBoard } from './SquareHighlightBoard';

--- a/apps/web/src/app/[locale]/(public)/topics/squares/[square]/new/_actions/createPost.test.ts
+++ b/apps/web/src/app/[locale]/(public)/topics/squares/[square]/new/_actions/createPost.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createPost } from './createPost';
+
+const mockGetUser = vi.fn();
+const mockInsertValues = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: () =>
+    Promise.resolve({
+      auth: {
+        getUser: mockGetUser,
+      },
+    }),
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    insert: () => ({
+      values: mockInsertValues,
+    }),
+  },
+  topicPosts: {},
+}));
+
+const mockRedirect = vi.fn();
+vi.mock('next/navigation', () => ({
+  redirect: (...args: unknown[]) => {
+    mockRedirect(...args);
+    throw new Error('NEXT_REDIRECT');
+  },
+}));
+
+const testUserId = 'user-00000000-0000-0000-0000-000000000001';
+
+function makeFormData(content: string): FormData {
+  const fd = new FormData();
+  fd.set('content', content);
+  return fd;
+}
+
+describe('createPost', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('square validation', () => {
+    it('should return error for invalid square', async () => {
+      const result = await createPost('en', 'z9', {}, makeFormData('hello'));
+      expect(result).toEqual({ error: 'Invalid square' });
+      expect(mockGetUser).not.toHaveBeenCalled();
+    });
+
+    it('should return error for uppercase square', async () => {
+      const result = await createPost('en', 'A1', {}, makeFormData('hello'));
+      expect(result).toEqual({ error: 'Invalid square' });
+    });
+
+    it('should return error for empty square string', async () => {
+      const result = await createPost('en', '', {}, makeFormData('hello'));
+      expect(result).toEqual({ error: 'Invalid square' });
+    });
+
+    it('should return error for reversed square notation', async () => {
+      const result = await createPost('en', '1a', {}, makeFormData('hello'));
+      expect(result).toEqual({ error: 'Invalid square' });
+    });
+  });
+
+  describe('authentication', () => {
+    it('should return signInRequired when user is not authenticated', async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null } });
+
+      const result = await createPost('en', 'e4', {}, makeFormData('hello'));
+      expect(result).toEqual({ error: 'signInRequired' });
+      expect(mockInsertValues).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('content validation', () => {
+    beforeEach(() => {
+      mockGetUser.mockResolvedValue({ data: { user: { id: testUserId } } });
+    });
+
+    it('should return contentRequired when content is empty', async () => {
+      const result = await createPost('en', 'e4', {}, makeFormData(''));
+      expect(result).toEqual({ error: 'contentRequired' });
+      expect(mockInsertValues).not.toHaveBeenCalled();
+    });
+
+    it('should return contentRequired when content is only whitespace', async () => {
+      const result = await createPost('en', 'e4', {}, makeFormData('   '));
+      expect(result).toEqual({ error: 'contentRequired' });
+      expect(mockInsertValues).not.toHaveBeenCalled();
+    });
+
+    it('should return contentRequired when content field is missing', async () => {
+      const fd = new FormData();
+      const result = await createPost('en', 'e4', {}, fd);
+      expect(result).toEqual({ error: 'contentRequired' });
+      expect(mockInsertValues).not.toHaveBeenCalled();
+    });
+
+    it('should return contentTooLong when content exceeds 5000 characters', async () => {
+      const longContent = 'a'.repeat(5001);
+      const result = await createPost('en', 'e4', {}, makeFormData(longContent));
+      expect(result).toEqual({ error: 'contentTooLong' });
+      expect(mockInsertValues).not.toHaveBeenCalled();
+    });
+
+    it('should accept content at exactly 5000 characters', async () => {
+      const maxContent = 'a'.repeat(5000);
+      await expect(createPost('en', 'e4', {}, makeFormData(maxContent))).rejects.toThrow(
+        'NEXT_REDIRECT'
+      );
+      expect(mockInsertValues).toHaveBeenCalled();
+    });
+  });
+
+  describe('successful post creation', () => {
+    beforeEach(() => {
+      mockGetUser.mockResolvedValue({ data: { user: { id: testUserId } } });
+    });
+
+    it('should insert post and redirect on success', async () => {
+      await expect(createPost('en', 'e4', {}, makeFormData('My post about e4'))).rejects.toThrow(
+        'NEXT_REDIRECT'
+      );
+
+      expect(mockInsertValues).toHaveBeenCalledWith({
+        userId: testUserId,
+        topicType: 'square',
+        topicKey: 'e4',
+        content: 'My post about e4',
+      });
+
+      expect(mockRedirect).toHaveBeenCalledWith('/en/topics/squares/e4');
+    });
+
+    it('should trim whitespace from content', async () => {
+      await expect(createPost('ja', 'a1', {}, makeFormData('  trimmed content  '))).rejects.toThrow(
+        'NEXT_REDIRECT'
+      );
+
+      expect(mockInsertValues).toHaveBeenCalledWith({
+        userId: testUserId,
+        topicType: 'square',
+        topicKey: 'a1',
+        content: 'trimmed content',
+      });
+    });
+
+    it('should redirect to correct locale', async () => {
+      await expect(createPost('ja', 'h8', {}, makeFormData('post'))).rejects.toThrow(
+        'NEXT_REDIRECT'
+      );
+
+      expect(mockRedirect).toHaveBeenCalledWith('/ja/topics/squares/h8');
+    });
+  });
+
+  describe('validation order', () => {
+    it('should validate square before checking auth', async () => {
+      const result = await createPost('en', 'invalid', {}, makeFormData('hello'));
+      expect(result).toEqual({ error: 'Invalid square' });
+      expect(mockGetUser).not.toHaveBeenCalled();
+    });
+
+    it('should check auth before validating content', async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null } });
+      const result = await createPost('en', 'e4', {}, makeFormData(''));
+      expect(result).toEqual({ error: 'signInRequired' });
+      expect(mockInsertValues).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/app/[locale]/(public)/topics/squares/[square]/new/_actions/createPost.ts
+++ b/apps/web/src/app/[locale]/(public)/topics/squares/[square]/new/_actions/createPost.ts
@@ -1,0 +1,53 @@
+'use server';
+
+import { redirect } from 'next/navigation';
+
+import { db, topicPosts } from '@/lib/db';
+import { createClient } from '@/lib/supabase/server';
+
+import { isValidSquare } from '../../../_lib/squares';
+
+const MAX_CONTENT_LENGTH = 5000;
+
+type CreatePostState = {
+  error?: string;
+};
+
+export async function createPost(
+  locale: string,
+  square: string,
+  _prevState: CreatePostState,
+  formData: FormData
+): Promise<CreatePostState> {
+  if (!isValidSquare(square)) {
+    return { error: 'Invalid square' };
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: 'signInRequired' };
+  }
+
+  const content = formData.get('content');
+
+  if (!content || typeof content !== 'string' || content.trim().length === 0) {
+    return { error: 'contentRequired' };
+  }
+
+  if (content.length > MAX_CONTENT_LENGTH) {
+    return { error: 'contentTooLong' };
+  }
+
+  await db.insert(topicPosts).values({
+    userId: user.id,
+    topicType: 'square',
+    topicKey: square,
+    content: content.trim(),
+  });
+
+  redirect(`/${locale}/topics/squares/${square}`);
+}

--- a/apps/web/src/app/[locale]/(public)/topics/squares/[square]/new/_components/NewPostForm.tsx
+++ b/apps/web/src/app/[locale]/(public)/topics/squares/[square]/new/_components/NewPostForm.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useActionState } from 'react';
+
+import { useTranslations } from 'next-intl';
+
+import { Button, Textarea } from '@/app/_components';
+
+import { createPost } from '../_actions/createPost';
+
+type Props = {
+  locale: string;
+  square: string;
+};
+
+export function NewPostForm({ locale, square }: Props) {
+  const t = useTranslations('topics.squares.newPostForm');
+  const boundCreatePost = createPost.bind(null, locale, square);
+  const [state, formAction, isPending] = useActionState(boundCreatePost, {});
+
+  const errorMessage = state.error
+    ? t.has(state.error)
+      ? t(state.error as 'contentRequired' | 'contentTooLong' | 'error' | 'signInRequired')
+      : t('error')
+    : null;
+
+  return (
+    <form action={formAction} className="space-y-4">
+      {errorMessage && (
+        <div className="p-3 rounded-md bg-destructive/10 text-destructive text-sm">
+          {errorMessage}
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <label htmlFor="content" className="block text-sm font-medium text-foreground">
+          {t('contentLabel')}
+        </label>
+        <Textarea
+          id="content"
+          name="content"
+          rows={6}
+          maxLength={5000}
+          placeholder={t('contentPlaceholder')}
+          required
+        />
+      </div>
+
+      <Button type="submit" variant="primary" fullWidth disabled={isPending} loading={isPending}>
+        {isPending ? t('submitting') : t('submit')}
+      </Button>
+    </form>
+  );
+}

--- a/apps/web/src/app/[locale]/(public)/topics/squares/[square]/new/_components/index.ts
+++ b/apps/web/src/app/[locale]/(public)/topics/squares/[square]/new/_components/index.ts
@@ -1,0 +1,1 @@
+export { NewPostForm } from './NewPostForm';

--- a/apps/web/src/app/[locale]/(public)/topics/squares/[square]/new/page.tsx
+++ b/apps/web/src/app/[locale]/(public)/topics/squares/[square]/new/page.tsx
@@ -1,0 +1,74 @@
+import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import { redirect } from 'next/navigation';
+import { notFound } from 'next/navigation';
+
+import { createClient } from '@/lib/supabase/server';
+
+import { Breadcrumb, Divider, PagePanel, PageTitle } from '@/app/[locale]/_components';
+import { generateCanonicalMetadata } from '@/app/[locale]/_lib/metadata';
+import type { Locale } from '@/app/[locale]/_lib/types';
+
+import { isValidSquare } from '../../_lib/squares';
+import { NewPostForm } from './_components';
+
+type Props = {
+  params: Promise<{ locale: Locale; square: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale, square } = await params;
+
+  if (!isValidSquare(square)) {
+    return {};
+  }
+
+  const t = await getTranslations({ locale, namespace: 'metadata.topicsSquareNewPost' });
+
+  return {
+    ...generateCanonicalMetadata({ locale, path: `topics/squares/${square}/new` }),
+    title: t('title', { square: square }),
+    description: t('description', { square: square }),
+  };
+}
+
+export default async function NewPostPage({ params }: Props) {
+  const { locale, square } = await params;
+
+  if (!isValidSquare(square)) {
+    notFound();
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect(`/${locale}/sign-in?toast=sign_in_required`);
+  }
+
+  const t = await getTranslations({ locale, namespace: 'topics' });
+
+  return (
+    <div className="space-y-8">
+      <PageTitle>{t('squares.newPostForm.title', { square: square })}</PageTitle>
+
+      <PagePanel>
+        <NewPostForm locale={locale} square={square} />
+
+        <Divider />
+
+        <Breadcrumb
+          items={[
+            { label: t('title'), href: '/topics' },
+            { label: t('squares.title'), href: '/topics/squares' },
+            { label: square, href: `/topics/squares/${square}` },
+            { label: t('squares.newPost') },
+          ]}
+          locale={locale}
+        />
+      </PagePanel>
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/(public)/topics/squares/[square]/page.tsx
+++ b/apps/web/src/app/[locale]/(public)/topics/squares/[square]/page.tsx
@@ -15,7 +15,7 @@ import {
 import { generateCanonicalMetadata } from '@/app/[locale]/_lib/metadata';
 import type { Locale } from '@/app/[locale]/_lib/types';
 
-import { getPostsForSquare } from '../_lib/queries';
+import { getPostsWithReplyMeta } from '../_lib/queries';
 import { isValidSquare } from '../_lib/squares';
 import { PostCard, SquareHighlightBoard } from './_components';
 
@@ -47,7 +47,7 @@ export default async function SquarePostsPage({ params }: Props) {
   }
 
   const t = await getTranslations({ locale, namespace: 'topics' });
-  const posts = await getPostsForSquare(square);
+  const posts = await getPostsWithReplyMeta(square);
 
   return (
     <div className="space-y-8">

--- a/apps/web/src/app/[locale]/(public)/topics/squares/[square]/page.tsx
+++ b/apps/web/src/app/[locale]/(public)/topics/squares/[square]/page.tsx
@@ -1,0 +1,96 @@
+import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import { notFound } from 'next/navigation';
+
+import { Button } from '@/app/_components';
+import { Link } from '@/i18n/routing';
+
+import {
+  Breadcrumb,
+  Divider,
+  PagePanel,
+  PageTitle,
+  SectionTitle,
+} from '@/app/[locale]/_components';
+import { generateCanonicalMetadata } from '@/app/[locale]/_lib/metadata';
+import type { Locale } from '@/app/[locale]/_lib/types';
+
+import { getPostsForSquare } from '../_lib/queries';
+import { isValidSquare } from '../_lib/squares';
+import { PostCard, SquareHighlightBoard } from './_components';
+
+type Props = {
+  params: Promise<{ locale: Locale; square: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale, square } = await params;
+
+  if (!isValidSquare(square)) {
+    return {};
+  }
+
+  const t = await getTranslations({ locale, namespace: 'metadata.topicsSquare' });
+
+  return {
+    ...generateCanonicalMetadata({ locale, path: `topics/squares/${square}` }),
+    title: t('title', { square }),
+    description: t('description', { square }),
+  };
+}
+
+export default async function SquarePostsPage({ params }: Props) {
+  const { locale, square } = await params;
+
+  if (!isValidSquare(square)) {
+    notFound();
+  }
+
+  const t = await getTranslations({ locale, namespace: 'topics' });
+  const posts = await getPostsForSquare(square);
+
+  return (
+    <div className="space-y-8">
+      <PageTitle>{t('squares.pageTitle')}</PageTitle>
+
+      <PagePanel>
+        <SectionTitle>{square}</SectionTitle>
+
+        <SquareHighlightBoard square={square} />
+
+        <p className="text-sm text-muted-foreground">
+          {t('squares.postCount', { count: posts.length })}
+        </p>
+
+        <div>
+          <Link href={`/topics/squares/${square}/new`} locale={locale}>
+            <Button variant="primary" asChild>
+              {t('squares.newPost')}
+            </Button>
+          </Link>
+        </div>
+
+        {posts.length === 0 ? (
+          <p className="text-muted-foreground text-center py-8">{t('squares.noPosts')}</p>
+        ) : (
+          <div className="space-y-3">
+            {posts.map((post) => (
+              <PostCard key={post.id} post={post} locale={locale} square={square} />
+            ))}
+          </div>
+        )}
+
+        <Divider />
+
+        <Breadcrumb
+          items={[
+            { label: t('title'), href: '/topics' },
+            { label: t('squares.title'), href: '/topics/squares' },
+            { label: square },
+          ]}
+          locale={locale}
+        />
+      </PagePanel>
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/(public)/topics/squares/[square]/posts/[postId]/_actions/createReply.test.ts
+++ b/apps/web/src/app/[locale]/(public)/topics/squares/[square]/posts/[postId]/_actions/createReply.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createReply } from './createReply';
+
+const mockGetUser = vi.fn();
+const mockInsertValues = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: () =>
+    Promise.resolve({
+      auth: {
+        getUser: mockGetUser,
+      },
+    }),
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    insert: () => ({
+      values: mockInsertValues,
+    }),
+  },
+  topicPosts: {},
+}));
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}));
+
+const testUserId = 'user-00000000-0000-0000-0000-000000000001';
+const testPostId = 'post-00000000-0000-0000-0000-000000000001';
+
+function makeFormData(content: string): FormData {
+  const fd = new FormData();
+  fd.set('content', content);
+  return fd;
+}
+
+describe('createReply', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('square validation', () => {
+    it('should return error for invalid square', async () => {
+      const result = await createReply('en', 'z9', testPostId, {}, makeFormData('hello'));
+      expect(result).toEqual({ error: 'Invalid square' });
+      expect(mockGetUser).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('authentication', () => {
+    it('should return signInRequired when user is not authenticated', async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null } });
+
+      const result = await createReply('en', 'e4', testPostId, {}, makeFormData('hello'));
+      expect(result).toEqual({ error: 'signInRequired' });
+      expect(mockInsertValues).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('content validation', () => {
+    beforeEach(() => {
+      mockGetUser.mockResolvedValue({ data: { user: { id: testUserId } } });
+    });
+
+    it('should return contentRequired when content is empty', async () => {
+      const result = await createReply('en', 'e4', testPostId, {}, makeFormData(''));
+      expect(result).toEqual({ error: 'contentRequired' });
+      expect(mockInsertValues).not.toHaveBeenCalled();
+    });
+
+    it('should return contentRequired when content is only whitespace', async () => {
+      const result = await createReply('en', 'e4', testPostId, {}, makeFormData('   '));
+      expect(result).toEqual({ error: 'contentRequired' });
+      expect(mockInsertValues).not.toHaveBeenCalled();
+    });
+
+    it('should return contentRequired when content field is missing', async () => {
+      const fd = new FormData();
+      const result = await createReply('en', 'e4', testPostId, {}, fd);
+      expect(result).toEqual({ error: 'contentRequired' });
+      expect(mockInsertValues).not.toHaveBeenCalled();
+    });
+
+    it('should return contentTooLong when content exceeds 5000 characters', async () => {
+      const longContent = 'a'.repeat(5001);
+      const result = await createReply('en', 'e4', testPostId, {}, makeFormData(longContent));
+      expect(result).toEqual({ error: 'contentTooLong' });
+      expect(mockInsertValues).not.toHaveBeenCalled();
+    });
+
+    it('should accept content at exactly 5000 characters', async () => {
+      const maxContent = 'a'.repeat(5000);
+      const result = await createReply('en', 'e4', testPostId, {}, makeFormData(maxContent));
+      expect(result).toEqual({});
+      expect(mockInsertValues).toHaveBeenCalled();
+    });
+  });
+
+  describe('successful reply creation', () => {
+    beforeEach(() => {
+      mockGetUser.mockResolvedValue({ data: { user: { id: testUserId } } });
+    });
+
+    it('should insert reply with correct parentId, topicType, and topicKey', async () => {
+      const result = await createReply(
+        'en',
+        'e4',
+        testPostId,
+        {},
+        makeFormData('My reply about e4')
+      );
+
+      expect(result).toEqual({});
+      expect(mockInsertValues).toHaveBeenCalledWith({
+        userId: testUserId,
+        topicType: 'square',
+        topicKey: 'e4',
+        parentId: testPostId,
+        content: 'My reply about e4',
+      });
+    });
+
+    it('should trim whitespace from content', async () => {
+      const result = await createReply(
+        'ja',
+        'a1',
+        testPostId,
+        {},
+        makeFormData('  trimmed reply  ')
+      );
+
+      expect(result).toEqual({});
+      expect(mockInsertValues).toHaveBeenCalledWith({
+        userId: testUserId,
+        topicType: 'square',
+        topicKey: 'a1',
+        parentId: testPostId,
+        content: 'trimmed reply',
+      });
+    });
+  });
+
+  describe('validation order', () => {
+    it('should validate square before checking auth', async () => {
+      const result = await createReply('en', 'invalid', testPostId, {}, makeFormData('hello'));
+      expect(result).toEqual({ error: 'Invalid square' });
+      expect(mockGetUser).not.toHaveBeenCalled();
+    });
+
+    it('should check auth before validating content', async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null } });
+      const result = await createReply('en', 'e4', testPostId, {}, makeFormData(''));
+      expect(result).toEqual({ error: 'signInRequired' });
+      expect(mockInsertValues).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/app/[locale]/(public)/topics/squares/[square]/posts/[postId]/_actions/createReply.ts
+++ b/apps/web/src/app/[locale]/(public)/topics/squares/[square]/posts/[postId]/_actions/createReply.ts
@@ -1,0 +1,57 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+
+import { db, topicPosts } from '@/lib/db';
+import { createClient } from '@/lib/supabase/server';
+
+import { isValidSquare } from '../../../../_lib/squares';
+
+const MAX_CONTENT_LENGTH = 5000;
+
+type CreateReplyState = {
+  error?: string;
+};
+
+export async function createReply(
+  locale: string,
+  square: string,
+  postId: string,
+  _prevState: CreateReplyState,
+  formData: FormData
+): Promise<CreateReplyState> {
+  if (!isValidSquare(square)) {
+    return { error: 'Invalid square' };
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: 'signInRequired' };
+  }
+
+  const content = formData.get('content');
+
+  if (!content || typeof content !== 'string' || content.trim().length === 0) {
+    return { error: 'contentRequired' };
+  }
+
+  if (content.length > MAX_CONTENT_LENGTH) {
+    return { error: 'contentTooLong' };
+  }
+
+  await db.insert(topicPosts).values({
+    userId: user.id,
+    topicType: 'square',
+    topicKey: square,
+    parentId: postId,
+    content: content.trim(),
+  });
+
+  revalidatePath(`/${locale}/topics/squares/${square}/posts/${postId}`);
+
+  return {};
+}

--- a/apps/web/src/app/[locale]/(public)/topics/squares/[square]/posts/[postId]/_components/ReplyForm.tsx
+++ b/apps/web/src/app/[locale]/(public)/topics/squares/[square]/posts/[postId]/_components/ReplyForm.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useActionState } from 'react';
+
+import { useTranslations } from 'next-intl';
+
+import { Button, Textarea } from '@/app/_components';
+
+import { createReply } from '../_actions/createReply';
+
+type Props = {
+  locale: string;
+  square: string;
+  postId: string;
+};
+
+export function ReplyForm({ locale, square, postId }: Props) {
+  const t = useTranslations('topics.squares.replies');
+  const boundCreateReply = createReply.bind(null, locale, square, postId);
+  const [state, formAction, isPending] = useActionState(boundCreateReply, {});
+
+  const errorMessage = state.error
+    ? t.has(state.error)
+      ? t(state.error as 'contentRequired' | 'contentTooLong' | 'error' | 'signInRequired')
+      : t('error')
+    : null;
+
+  return (
+    <form action={formAction} className="space-y-4">
+      {errorMessage && (
+        <div className="p-3 rounded-md bg-destructive/10 text-destructive text-sm">
+          {errorMessage}
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <label htmlFor="reply-content" className="block text-sm font-medium text-foreground">
+          {t('contentLabel')}
+        </label>
+        <Textarea
+          id="reply-content"
+          name="content"
+          rows={4}
+          maxLength={5000}
+          placeholder={t('contentPlaceholder')}
+          required
+        />
+      </div>
+
+      <Button type="submit" variant="primary" fullWidth disabled={isPending} loading={isPending}>
+        {isPending ? t('submitting') : t('submit')}
+      </Button>
+    </form>
+  );
+}

--- a/apps/web/src/app/[locale]/(public)/topics/squares/[square]/posts/[postId]/_components/ReplyList.tsx
+++ b/apps/web/src/app/[locale]/(public)/topics/squares/[square]/posts/[postId]/_components/ReplyList.tsx
@@ -1,0 +1,57 @@
+import Image from 'next/image';
+
+import type { TopicPostWithAuthor } from '../../../../_lib/queries';
+
+type Props = {
+  replies: TopicPostWithAuthor[];
+  locale: string;
+};
+
+export function ReplyList({ replies, locale }: Props) {
+  return (
+    <div className="space-y-4">
+      {replies.map((reply) => {
+        const displayName = reply.author?.displayName || reply.author?.username || 'Anonymous';
+        return (
+          <div key={reply.id} className="p-4 bg-card border border-border rounded-lg space-y-3">
+            <div className="flex items-center gap-3">
+              {reply.author?.avatarUrl ? (
+                <Image
+                  src={reply.author.avatarUrl}
+                  alt={displayName}
+                  width={32}
+                  height={32}
+                  className="rounded-full flex-shrink-0"
+                />
+              ) : (
+                <div className="w-8 h-8 rounded-full bg-muted flex items-center justify-center flex-shrink-0">
+                  <span className="text-xs text-muted-foreground">
+                    {displayName.charAt(0).toUpperCase()}
+                  </span>
+                </div>
+              )}
+              <div className="flex items-baseline gap-2">
+                <span className="font-medium text-foreground text-sm">{displayName}</span>
+                <time
+                  dateTime={reply.createdAt.toISOString()}
+                  className="text-xs text-muted-foreground"
+                >
+                  {reply.createdAt.toLocaleDateString(locale, {
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric',
+                    hour: '2-digit',
+                    minute: '2-digit',
+                  })}
+                </time>
+              </div>
+            </div>
+            <div className="text-foreground whitespace-pre-wrap break-words text-sm leading-relaxed">
+              {reply.content}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/(public)/topics/squares/[square]/posts/[postId]/_components/index.ts
+++ b/apps/web/src/app/[locale]/(public)/topics/squares/[square]/posts/[postId]/_components/index.ts
@@ -1,0 +1,2 @@
+export { ReplyForm } from './ReplyForm';
+export { ReplyList } from './ReplyList';

--- a/apps/web/src/app/[locale]/(public)/topics/squares/[square]/posts/[postId]/page.tsx
+++ b/apps/web/src/app/[locale]/(public)/topics/squares/[square]/posts/[postId]/page.tsx
@@ -1,0 +1,138 @@
+import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import Image from 'next/image';
+import { notFound } from 'next/navigation';
+
+import { Link } from '@/i18n/routing';
+
+import {
+  Breadcrumb,
+  Divider,
+  PagePanel,
+  PageTitle,
+  SectionTitle,
+} from '@/app/[locale]/_components';
+import { generateCanonicalMetadata } from '@/app/[locale]/_lib/metadata';
+import type { Locale } from '@/app/[locale]/_lib/types';
+
+import { getPostById } from '../../../_lib/queries';
+import { isValidSquare } from '../../../_lib/squares';
+import { SquareHighlightBoard } from '../../_components';
+
+type Props = {
+  params: Promise<{ locale: Locale; square: string; postId: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale, square, postId } = await params;
+
+  if (!isValidSquare(square)) {
+    return {};
+  }
+
+  const post = await getPostById(postId, square);
+  if (!post) {
+    return {};
+  }
+
+  const t = await getTranslations({ locale, namespace: 'metadata.topicsSquarePost' });
+
+  return {
+    ...generateCanonicalMetadata({
+      locale,
+      path: `topics/squares/${square}/posts/${postId}`,
+    }),
+    title: t('title', { square }),
+    description: t('description', { square }),
+  };
+}
+
+export default async function PostDetailPage({ params }: Props) {
+  const { locale, square, postId } = await params;
+
+  if (!isValidSquare(square)) {
+    notFound();
+  }
+
+  const post = await getPostById(postId, square);
+  if (!post) {
+    notFound();
+  }
+
+  const t = await getTranslations({ locale, namespace: 'topics' });
+  const displayName = post.author?.displayName || post.author?.username || 'Anonymous';
+
+  return (
+    <div className="space-y-8">
+      <PageTitle>{t('squares.pageTitle')}</PageTitle>
+
+      <PagePanel>
+        <SectionTitle>
+          {t('squares.postDetail.authorView', { author: displayName, square })}
+        </SectionTitle>
+
+        <SquareHighlightBoard square={square} />
+
+        <div>
+          <Link
+            href={`/topics/squares/${square}`}
+            locale={locale}
+            className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            &larr; {t('squares.postDetail.backToSquare', { square })}
+          </Link>
+        </div>
+
+        <div className="space-y-6">
+          <div className="flex items-start gap-3">
+            {post.author?.avatarUrl ? (
+              <Image
+                src={post.author.avatarUrl}
+                alt={displayName}
+                width={40}
+                height={40}
+                className="rounded-full flex-shrink-0"
+              />
+            ) : (
+              <div className="w-10 h-10 rounded-full bg-muted flex items-center justify-center flex-shrink-0">
+                <span className="text-sm text-muted-foreground">
+                  {displayName.charAt(0).toUpperCase()}
+                </span>
+              </div>
+            )}
+            <div>
+              <span className="font-medium text-foreground">{displayName}</span>
+              <div className="text-sm text-muted-foreground">
+                <time dateTime={post.createdAt.toISOString()}>
+                  {post.createdAt.toLocaleDateString(locale, {
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric',
+                    hour: '2-digit',
+                    minute: '2-digit',
+                  })}
+                </time>
+              </div>
+            </div>
+          </div>
+
+          <div className="text-foreground whitespace-pre-wrap break-words leading-relaxed">
+            {post.content}
+          </div>
+        </div>
+
+        <Divider />
+
+        <Breadcrumb
+          items={[
+            { label: t('title'), href: '/topics' },
+            { label: t('squares.title'), href: '/topics/squares' },
+            { label: square, href: `/topics/squares/${square}` },
+            { label: t('squares.readMore') },
+          ]}
+          locale={locale}
+        />
+      </PagePanel>
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/(public)/topics/squares/[square]/posts/[postId]/page.tsx
+++ b/apps/web/src/app/[locale]/(public)/topics/squares/[square]/posts/[postId]/page.tsx
@@ -5,19 +5,16 @@ import { notFound } from 'next/navigation';
 
 import { Link } from '@/i18n/routing';
 
-import {
-  Breadcrumb,
-  Divider,
-  PagePanel,
-  PageTitle,
-  SectionTitle,
-} from '@/app/[locale]/_components';
+import { createClient } from '@/lib/supabase/server';
+
+import { Breadcrumb, PagePanel, PageTitle, SectionTitle } from '@/app/[locale]/_components';
 import { generateCanonicalMetadata } from '@/app/[locale]/_lib/metadata';
 import type { Locale } from '@/app/[locale]/_lib/types';
 
-import { getPostById } from '../../../_lib/queries';
+import { getPostById, getRepliesByPostId } from '../../../_lib/queries';
 import { isValidSquare } from '../../../_lib/squares';
 import { SquareHighlightBoard } from '../../_components';
+import { ReplyForm, ReplyList } from './_components';
 
 type Props = {
   params: Promise<{ locale: Locale; square: string; postId: string }>;
@@ -58,6 +55,11 @@ export default async function PostDetailPage({ params }: Props) {
   if (!post) {
     notFound();
   }
+
+  const [replies, supabase] = await Promise.all([getRepliesByPostId(postId), createClient()]);
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
   const t = await getTranslations({ locale, namespace: 'topics' });
   const displayName = post.author?.displayName || post.author?.username || 'Anonymous';
@@ -121,7 +123,31 @@ export default async function PostDetailPage({ params }: Props) {
           </div>
         </div>
 
-        <Divider />
+        <div className="space-y-4">
+          <SectionTitle>
+            {t('squares.replies.title')} ({t('squares.replies.count', { count: replies.length })})
+          </SectionTitle>
+
+          {replies.length > 0 ? (
+            <ReplyList replies={replies} locale={locale} />
+          ) : (
+            <p className="text-sm text-muted-foreground">{t('squares.replies.noReplies')}</p>
+          )}
+        </div>
+
+        {user ? (
+          <ReplyForm locale={locale} square={square} postId={postId} />
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            <Link
+              href="/sign-in"
+              locale={locale}
+              className="text-foreground underline hover:text-muted-foreground transition-colors"
+            >
+              {t('squares.replies.loginToReply')}
+            </Link>
+          </p>
+        )}
 
         <Breadcrumb
           items={[

--- a/apps/web/src/app/[locale]/(public)/topics/squares/_components/SquareBoard.tsx
+++ b/apps/web/src/app/[locale]/(public)/topics/squares/_components/SquareBoard.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { BoardLayout } from '@/app/_components';
+import type { SquareRenderInfo } from '@/app/_components';
+import { Link } from '@/i18n/routing';
+
+import { DEFAULT_BOARD_THEME, getBoardThemeColors } from '@/lib/boardThemes';
+
+type Props = {
+  locale: string;
+  postCounts: Record<string, number>;
+};
+
+export function SquareBoard({ locale, postCounts }: Props) {
+  const themeColors = getBoardThemeColors(DEFAULT_BOARD_THEME);
+
+  const renderSquare = ({ square, isLight }: SquareRenderInfo) => {
+    const postCount = postCounts[square] || 0;
+
+    return (
+      <Link
+        href={`/topics/squares/${square}`}
+        locale={locale}
+        className={`flex flex-col items-center justify-center w-full h-full ${
+          isLight ? themeColors.lightCoordinates : themeColors.darkCoordinates
+        }`}
+      >
+        <span className="font-medium text-xs sm:text-sm leading-none">{square}</span>
+        {postCount > 0 && (
+          <span className="text-[10px] leading-none mt-0.5 opacity-70">{postCount}</span>
+        )}
+      </Link>
+    );
+  };
+
+  return (
+    <div className="max-w-lg mx-auto">
+      <BoardLayout
+        showCoordinates={false}
+        rounded={true}
+        themeColors={themeColors}
+        renderSquare={renderSquare}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/(public)/topics/squares/_components/index.ts
+++ b/apps/web/src/app/[locale]/(public)/topics/squares/_components/index.ts
@@ -1,0 +1,1 @@
+export { SquareBoard } from './SquareBoard';

--- a/apps/web/src/app/[locale]/(public)/topics/squares/_lib/queries.test.ts
+++ b/apps/web/src/app/[locale]/(public)/topics/squares/_lib/queries.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { db } from '@/lib/db';
 
-import { getRepliesByPostId } from './queries';
+import { getPostsWithReplyMeta, getRepliesByPostId } from './queries';
 
 vi.mock('@/lib/db', () => {
   const mockDb = {
@@ -37,7 +37,16 @@ const mockDb = vi.mocked(db);
  */
 function mockChain(rows: unknown[]) {
   const chain: Record<string, unknown> = {};
-  const methods = ['select', 'from', 'leftJoin', 'where', 'orderBy', 'groupBy', 'limit'];
+  const methods = [
+    'select',
+    'from',
+    'leftJoin',
+    'innerJoin',
+    'where',
+    'orderBy',
+    'groupBy',
+    'limit',
+  ];
   for (const m of methods) {
     chain[m] = vi.fn().mockReturnValue(chain);
   }
@@ -206,5 +215,269 @@ describe('getRepliesByPostId', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].author).toBeNull();
+  });
+});
+
+describe('getPostsWithReplyMeta', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  /**
+   * Helper: configure sequential db.select calls for getPostsWithReplyMeta.
+   * Call 1: getPostsForSquare (posts)
+   * Call 2: replyStats (counts + latestReplyAt)
+   * Call 3: repliesWithAvatars (avatar rows)
+   */
+  function setupMocks(postRows: unknown[], statsRows: unknown[], avatarRows: unknown[]) {
+    const postsChain = mockChain(postRows);
+    const statsChain = mockChain(statsRows);
+    const avatarsChain = mockChain(avatarRows);
+
+    mockDb.select
+      .mockReturnValueOnce(postsChain as unknown as ReturnType<typeof mockDb.select>)
+      .mockReturnValueOnce(statsChain as unknown as ReturnType<typeof mockDb.select>)
+      .mockReturnValueOnce(avatarsChain as unknown as ReturnType<typeof mockDb.select>);
+  }
+
+  const postRow = (id: string) => ({
+    post: {
+      id,
+      userId: 'user-1',
+      topicType: 'square',
+      topicKey: 'e4',
+      parentId: null,
+      content: `Post ${id}`,
+      createdAt: new Date('2025-01-01T00:00:00Z'),
+    },
+    author: {
+      username: 'alice',
+      displayName: 'Alice',
+      avatarUrl: 'https://example.com/alice.png',
+    },
+  });
+
+  it('should return empty array when no posts exist', async () => {
+    const chain = mockChain([]);
+    mockDb.select.mockReturnValue(chain as unknown as ReturnType<typeof mockDb.select>);
+
+    const result = await getPostsWithReplyMeta('e4');
+
+    expect(result).toEqual([]);
+  });
+
+  it('should return empty replyMeta for posts with no replies', async () => {
+    setupMocks([postRow(testPostId)], [], []);
+
+    const result = await getPostsWithReplyMeta('e4');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].replyMeta).toEqual({
+      replyCount: 0,
+      latestReplyAt: null,
+      repliers: [],
+    });
+  });
+
+  it('should return correct reply count', async () => {
+    const statsRows = [
+      { parentId: testPostId, replyCount: 5, latestReplyAt: new Date('2025-01-10T00:00:00Z') },
+    ];
+
+    setupMocks([postRow(testPostId)], statsRows, []);
+
+    const result = await getPostsWithReplyMeta('e4');
+
+    expect(result[0].replyMeta.replyCount).toBe(5);
+  });
+
+  it('should return correct latestReplyAt', async () => {
+    const latestDate = new Date('2025-02-15T10:30:00Z');
+    const statsRows = [{ parentId: testPostId, replyCount: 3, latestReplyAt: latestDate }];
+
+    setupMocks([postRow(testPostId)], statsRows, []);
+
+    const result = await getPostsWithReplyMeta('e4');
+
+    expect(result[0].replyMeta.latestReplyAt).toEqual(latestDate);
+  });
+
+  it('should return up to 3 unique repliers', async () => {
+    const statsRows = [
+      { parentId: testPostId, replyCount: 4, latestReplyAt: new Date('2025-01-04T00:00:00Z') },
+    ];
+    const avatarRows = [
+      {
+        parentId: testPostId,
+        userId: 'user-a',
+        avatarUrl: 'https://example.com/a.png',
+        displayName: 'A',
+        username: 'a',
+        createdAt: new Date('2025-01-04T00:00:00Z'),
+      },
+      {
+        parentId: testPostId,
+        userId: 'user-b',
+        avatarUrl: 'https://example.com/b.png',
+        displayName: 'B',
+        username: 'b',
+        createdAt: new Date('2025-01-03T00:00:00Z'),
+      },
+      {
+        parentId: testPostId,
+        userId: 'user-c',
+        avatarUrl: 'https://example.com/c.png',
+        displayName: 'C',
+        username: 'c',
+        createdAt: new Date('2025-01-02T00:00:00Z'),
+      },
+      {
+        parentId: testPostId,
+        userId: 'user-d',
+        avatarUrl: 'https://example.com/d.png',
+        displayName: 'D',
+        username: 'd',
+        createdAt: new Date('2025-01-01T00:00:00Z'),
+      },
+    ];
+
+    setupMocks([postRow(testPostId)], statsRows, avatarRows);
+
+    const result = await getPostsWithReplyMeta('e4');
+
+    expect(result[0].replyMeta.repliers).toHaveLength(3);
+    expect(result[0].replyMeta.repliers).toEqual([
+      { avatarUrl: 'https://example.com/a.png', displayName: 'A' },
+      { avatarUrl: 'https://example.com/b.png', displayName: 'B' },
+      { avatarUrl: 'https://example.com/c.png', displayName: 'C' },
+    ]);
+  });
+
+  it('should deduplicate repliers from the same user replying multiple times', async () => {
+    const statsRows = [
+      { parentId: testPostId, replyCount: 3, latestReplyAt: new Date('2025-01-03T00:00:00Z') },
+    ];
+    const avatarRows = [
+      {
+        parentId: testPostId,
+        userId: 'user-alice',
+        avatarUrl: 'https://example.com/alice.png',
+        displayName: 'Alice',
+        username: 'alice',
+        createdAt: new Date('2025-01-03T00:00:00Z'),
+      },
+      {
+        parentId: testPostId,
+        userId: 'user-alice',
+        avatarUrl: 'https://example.com/alice.png',
+        displayName: 'Alice',
+        username: 'alice',
+        createdAt: new Date('2025-01-02T00:00:00Z'),
+      },
+      {
+        parentId: testPostId,
+        userId: 'user-bob',
+        avatarUrl: 'https://example.com/bob.png',
+        displayName: 'Bob',
+        username: 'bob',
+        createdAt: new Date('2025-01-01T00:00:00Z'),
+      },
+    ];
+
+    setupMocks([postRow(testPostId)], statsRows, avatarRows);
+
+    const result = await getPostsWithReplyMeta('e4');
+
+    expect(result[0].replyMeta.repliers).toEqual([
+      { avatarUrl: 'https://example.com/alice.png', displayName: 'Alice' },
+      { avatarUrl: 'https://example.com/bob.png', displayName: 'Bob' },
+    ]);
+  });
+
+  it('should include repliers with no avatar URL (with displayName)', async () => {
+    const statsRows = [
+      { parentId: testPostId, replyCount: 2, latestReplyAt: new Date('2025-01-02T00:00:00Z') },
+    ];
+    const avatarRows = [
+      {
+        parentId: testPostId,
+        userId: 'user-no-avatar',
+        avatarUrl: null,
+        displayName: 'NoAvatar',
+        username: 'noavatar',
+        createdAt: new Date('2025-01-02T00:00:00Z'),
+      },
+      {
+        parentId: testPostId,
+        userId: 'user-bob',
+        avatarUrl: 'https://example.com/bob.png',
+        displayName: 'Bob',
+        username: 'bob',
+        createdAt: new Date('2025-01-01T00:00:00Z'),
+      },
+    ];
+
+    setupMocks([postRow(testPostId)], statsRows, avatarRows);
+
+    const result = await getPostsWithReplyMeta('e4');
+
+    expect(result[0].replyMeta.repliers).toEqual([
+      { avatarUrl: null, displayName: 'NoAvatar' },
+      { avatarUrl: 'https://example.com/bob.png', displayName: 'Bob' },
+    ]);
+  });
+
+  it('should handle multiple posts with different reply metadata', async () => {
+    const postRows = [postRow(testPostId), postRow(otherPostId)];
+    const statsRows = [
+      { parentId: testPostId, replyCount: 2, latestReplyAt: new Date('2025-01-05T00:00:00Z') },
+      { parentId: otherPostId, replyCount: 1, latestReplyAt: new Date('2025-01-03T00:00:00Z') },
+    ];
+    const avatarRows = [
+      {
+        parentId: testPostId,
+        userId: 'user-a',
+        avatarUrl: 'https://example.com/a.png',
+        displayName: 'A',
+        username: 'a',
+        createdAt: new Date('2025-01-05T00:00:00Z'),
+      },
+      {
+        parentId: otherPostId,
+        userId: 'user-b',
+        avatarUrl: 'https://example.com/b.png',
+        displayName: 'B',
+        username: 'b',
+        createdAt: new Date('2025-01-03T00:00:00Z'),
+      },
+    ];
+
+    setupMocks(postRows, statsRows, avatarRows);
+
+    const result = await getPostsWithReplyMeta('e4');
+
+    expect(result).toHaveLength(2);
+    expect(result[0].replyMeta.replyCount).toBe(2);
+    expect(result[0].replyMeta.repliers).toEqual([
+      { avatarUrl: 'https://example.com/a.png', displayName: 'A' },
+    ]);
+    expect(result[1].replyMeta.replyCount).toBe(1);
+    expect(result[1].replyMeta.repliers).toEqual([
+      { avatarUrl: 'https://example.com/b.png', displayName: 'B' },
+    ]);
+  });
+
+  it('should preserve post and author data alongside replyMeta', async () => {
+    setupMocks([postRow(testPostId)], [], []);
+
+    const result = await getPostsWithReplyMeta('e4');
+
+    expect(result[0].id).toBe(testPostId);
+    expect(result[0].content).toBe(`Post ${testPostId}`);
+    expect(result[0].author).toEqual({
+      username: 'alice',
+      displayName: 'Alice',
+      avatarUrl: 'https://example.com/alice.png',
+    });
   });
 });

--- a/apps/web/src/app/[locale]/(public)/topics/squares/_lib/queries.test.ts
+++ b/apps/web/src/app/[locale]/(public)/topics/squares/_lib/queries.test.ts
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { db } from '@/lib/db';
+
+import { getRepliesByPostId } from './queries';
+
+vi.mock('@/lib/db', () => {
+  const mockDb = {
+    select: vi.fn(),
+  };
+
+  return {
+    db: mockDb,
+    topicPosts: {
+      id: 'topic_posts.id',
+      userId: 'topic_posts.user_id',
+      topicType: 'topic_posts.topic_type',
+      topicKey: 'topic_posts.topic_key',
+      parentId: 'topic_posts.parent_id',
+      content: 'topic_posts.content',
+      createdAt: 'topic_posts.created_at',
+    },
+    profiles: {
+      id: 'profiles.id',
+      username: 'profiles.username',
+      displayName: 'profiles.display_name',
+      avatarUrl: 'profiles.avatar_url',
+    },
+  };
+});
+
+const mockDb = vi.mocked(db);
+
+/**
+ * Creates a chainable mock that resolves to `rows` when awaited.
+ * Each chained method returns the same object so the Drizzle-style chaining works.
+ */
+function mockChain(rows: unknown[]) {
+  const chain: Record<string, unknown> = {};
+  const methods = ['select', 'from', 'leftJoin', 'where', 'orderBy', 'groupBy', 'limit'];
+  for (const m of methods) {
+    chain[m] = vi.fn().mockReturnValue(chain);
+  }
+  chain.then = (resolve: (v: unknown) => void) => resolve(rows);
+  return chain;
+}
+
+const testPostId = 'post-00000000-0000-0000-0000-000000000001';
+const otherPostId = 'post-00000000-0000-0000-0000-000000000002';
+
+describe('getRepliesByPostId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return empty array when no replies exist', async () => {
+    const chain = mockChain([]);
+    mockDb.select.mockReturnValue(chain as unknown as ReturnType<typeof mockDb.select>);
+
+    const result = await getRepliesByPostId(testPostId);
+
+    expect(result).toEqual([]);
+  });
+
+  it('should return replies with author profile data', async () => {
+    const rows = [
+      {
+        post: {
+          id: 'reply-1',
+          userId: 'user-1',
+          topicType: 'square',
+          topicKey: 'e4',
+          parentId: testPostId,
+          content: 'First reply',
+          createdAt: new Date('2025-01-02T00:00:00Z'),
+        },
+        author: {
+          username: 'alice',
+          displayName: 'Alice',
+          avatarUrl: 'https://example.com/alice.png',
+        },
+      },
+    ];
+
+    const chain = mockChain(rows);
+    mockDb.select.mockReturnValue(chain as unknown as ReturnType<typeof mockDb.select>);
+
+    const result = await getRepliesByPostId(testPostId);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      id: 'reply-1',
+      userId: 'user-1',
+      topicType: 'square',
+      topicKey: 'e4',
+      parentId: testPostId,
+      content: 'First reply',
+      createdAt: new Date('2025-01-02T00:00:00Z'),
+      author: {
+        username: 'alice',
+        displayName: 'Alice',
+        avatarUrl: 'https://example.com/alice.png',
+      },
+    });
+  });
+
+  it('should return replies sorted by createdAt DESC (newest first)', async () => {
+    const rows = [
+      {
+        post: {
+          id: 'reply-newer',
+          userId: 'user-1',
+          topicType: 'square',
+          topicKey: 'e4',
+          parentId: testPostId,
+          content: 'Newer reply',
+          createdAt: new Date('2025-01-03T00:00:00Z'),
+        },
+        author: {
+          username: 'bob',
+          displayName: 'Bob',
+          avatarUrl: null,
+        },
+      },
+      {
+        post: {
+          id: 'reply-older',
+          userId: 'user-2',
+          topicType: 'square',
+          topicKey: 'e4',
+          parentId: testPostId,
+          content: 'Older reply',
+          createdAt: new Date('2025-01-01T00:00:00Z'),
+        },
+        author: {
+          username: 'alice',
+          displayName: 'Alice',
+          avatarUrl: 'https://example.com/alice.png',
+        },
+      },
+    ];
+
+    const chain = mockChain(rows);
+    mockDb.select.mockReturnValue(chain as unknown as ReturnType<typeof mockDb.select>);
+
+    const result = await getRepliesByPostId(testPostId);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('reply-newer');
+    expect(result[1].id).toBe('reply-older');
+  });
+
+  it('should only return replies for the specified postId (not other posts)', async () => {
+    // The mock returns only replies matching the postId passed to the query.
+    // We verify the where clause is called by checking db.select is invoked
+    // and only the matching rows are returned.
+    const matchingRows = [
+      {
+        post: {
+          id: 'reply-for-post-1',
+          userId: 'user-1',
+          topicType: 'square',
+          topicKey: 'e4',
+          parentId: testPostId,
+          content: 'Reply for post 1',
+          createdAt: new Date('2025-01-01T00:00:00Z'),
+        },
+        author: {
+          username: 'alice',
+          displayName: 'Alice',
+          avatarUrl: null,
+        },
+      },
+    ];
+
+    const chain = mockChain(matchingRows);
+    mockDb.select.mockReturnValue(chain as unknown as ReturnType<typeof mockDb.select>);
+
+    const result = await getRepliesByPostId(testPostId);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].parentId).toBe(testPostId);
+    expect(result[0].parentId).not.toBe(otherPostId);
+  });
+
+  it('should handle author being null (deleted user)', async () => {
+    const rows = [
+      {
+        post: {
+          id: 'reply-1',
+          userId: 'deleted-user',
+          topicType: 'square',
+          topicKey: 'd4',
+          parentId: testPostId,
+          content: 'Reply from deleted user',
+          createdAt: new Date('2025-01-01T00:00:00Z'),
+        },
+        author: null,
+      },
+    ];
+
+    const chain = mockChain(rows);
+    mockDb.select.mockReturnValue(chain as unknown as ReturnType<typeof mockDb.select>);
+
+    const result = await getRepliesByPostId(testPostId);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].author).toBeNull();
+  });
+});

--- a/apps/web/src/app/[locale]/(public)/topics/squares/_lib/queries.ts
+++ b/apps/web/src/app/[locale]/(public)/topics/squares/_lib/queries.ts
@@ -1,4 +1,4 @@
-import { and, count, desc, eq, isNull } from 'drizzle-orm';
+import { and, count, desc, eq, inArray, isNull, max } from 'drizzle-orm';
 
 import { db, profiles, topicPosts } from '@/lib/db';
 import type { Profile, TopicPost } from '@/lib/db';
@@ -92,6 +92,99 @@ export async function getPostById(
     ...results[0].post,
     author: results[0].author,
   };
+}
+
+export type Replier = {
+  avatarUrl: string | null;
+  displayName: string;
+};
+
+export type ReplyMeta = {
+  replyCount: number;
+  latestReplyAt: Date | null;
+  repliers: Replier[];
+};
+
+export type PostWithReplyMeta = TopicPostWithAuthor & {
+  replyMeta: ReplyMeta;
+};
+
+/**
+ * Get top-level posts for a square with reply metadata (count, latest reply, replier avatars).
+ * Uses two batch queries to avoid N+1.
+ */
+export async function getPostsWithReplyMeta(square: string): Promise<PostWithReplyMeta[]> {
+  const posts = await getPostsForSquare(square);
+
+  if (posts.length === 0) {
+    return [];
+  }
+
+  const postIds = posts.map((p) => p.id);
+
+  // Batch query 1: reply counts and latest reply timestamp per parent
+  const replyStats = await db
+    .select({
+      parentId: topicPosts.parentId,
+      replyCount: count(),
+      latestReplyAt: max(topicPosts.createdAt),
+    })
+    .from(topicPosts)
+    .where(inArray(topicPosts.parentId, postIds))
+    .groupBy(topicPosts.parentId);
+
+  // Batch query 2: replies with author info for replier display
+  const repliesWithAuthors = await db
+    .select({
+      parentId: topicPosts.parentId,
+      userId: topicPosts.userId,
+      avatarUrl: profiles.avatarUrl,
+      displayName: profiles.displayName,
+      username: profiles.username,
+      createdAt: topicPosts.createdAt,
+    })
+    .from(topicPosts)
+    .leftJoin(profiles, eq(topicPosts.userId, profiles.id))
+    .where(inArray(topicPosts.parentId, postIds))
+    .orderBy(desc(topicPosts.createdAt));
+
+  // Build lookup maps
+  const statsMap = new Map(
+    replyStats.map((r) => [
+      r.parentId,
+      { replyCount: r.replyCount, latestReplyAt: r.latestReplyAt },
+    ])
+  );
+
+  // Collect up to 3 unique repliers per post (most recent, deduplicated by userId)
+  const repliersMap = new Map<string, Replier[]>();
+  const seenUsers = new Map<string, Set<string>>();
+  for (const row of repliesWithAuthors) {
+    if (!row.parentId) continue;
+    const seen = seenUsers.get(row.parentId) ?? new Set();
+    if (seen.has(row.userId)) continue;
+    const existing = repliersMap.get(row.parentId) ?? [];
+    if (existing.length >= 3) continue;
+    seen.add(row.userId);
+    seenUsers.set(row.parentId, seen);
+    existing.push({
+      avatarUrl: row.avatarUrl,
+      displayName: row.displayName || row.username || 'Anonymous',
+    });
+    repliersMap.set(row.parentId, existing);
+  }
+
+  return posts.map((post) => {
+    const stats = statsMap.get(post.id);
+    return {
+      ...post,
+      replyMeta: {
+        replyCount: stats?.replyCount ?? 0,
+        latestReplyAt: stats?.latestReplyAt ?? null,
+        repliers: repliersMap.get(post.id) ?? [],
+      },
+    };
+  });
 }
 
 /**

--- a/apps/web/src/app/[locale]/(public)/topics/squares/_lib/queries.ts
+++ b/apps/web/src/app/[locale]/(public)/topics/squares/_lib/queries.ts
@@ -93,3 +93,27 @@ export async function getPostById(
     author: results[0].author,
   };
 }
+
+/**
+ * Get replies for a specific post
+ */
+export async function getRepliesByPostId(postId: string): Promise<TopicPostWithAuthor[]> {
+  const results = await db
+    .select({
+      post: topicPosts,
+      author: {
+        username: profiles.username,
+        displayName: profiles.displayName,
+        avatarUrl: profiles.avatarUrl,
+      },
+    })
+    .from(topicPosts)
+    .leftJoin(profiles, eq(topicPosts.userId, profiles.id))
+    .where(eq(topicPosts.parentId, postId))
+    .orderBy(desc(topicPosts.createdAt));
+
+  return results.map((r) => ({
+    ...r.post,
+    author: r.author,
+  }));
+}

--- a/apps/web/src/app/[locale]/(public)/topics/squares/_lib/queries.ts
+++ b/apps/web/src/app/[locale]/(public)/topics/squares/_lib/queries.ts
@@ -1,0 +1,95 @@
+import { and, count, desc, eq, isNull } from 'drizzle-orm';
+
+import { db, profiles, topicPosts } from '@/lib/db';
+import type { Profile, TopicPost } from '@/lib/db';
+
+/**
+ * Get post counts per square for the board overview
+ */
+export async function getSquarePostCounts(): Promise<Record<string, number>> {
+  const results = await db
+    .select({
+      topicKey: topicPosts.topicKey,
+      count: count(),
+    })
+    .from(topicPosts)
+    .where(and(eq(topicPosts.topicType, 'square'), isNull(topicPosts.parentId)))
+    .groupBy(topicPosts.topicKey);
+
+  const counts: Record<string, number> = {};
+  for (const row of results) {
+    counts[row.topicKey] = row.count;
+  }
+  return counts;
+}
+
+export type TopicPostWithAuthor = TopicPost & {
+  author: Pick<Profile, 'username' | 'displayName' | 'avatarUrl'> | null;
+};
+
+/**
+ * Get top-level posts for a specific square
+ */
+export async function getPostsForSquare(square: string): Promise<TopicPostWithAuthor[]> {
+  const results = await db
+    .select({
+      post: topicPosts,
+      author: {
+        username: profiles.username,
+        displayName: profiles.displayName,
+        avatarUrl: profiles.avatarUrl,
+      },
+    })
+    .from(topicPosts)
+    .leftJoin(profiles, eq(topicPosts.userId, profiles.id))
+    .where(
+      and(
+        eq(topicPosts.topicType, 'square'),
+        eq(topicPosts.topicKey, square),
+        isNull(topicPosts.parentId)
+      )
+    )
+    .orderBy(desc(topicPosts.createdAt));
+
+  return results.map((r) => ({
+    ...r.post,
+    author: r.author,
+  }));
+}
+
+/**
+ * Get a single post by ID, verifying it belongs to the given square
+ */
+export async function getPostById(
+  postId: string,
+  square: string
+): Promise<TopicPostWithAuthor | null> {
+  const results = await db
+    .select({
+      post: topicPosts,
+      author: {
+        username: profiles.username,
+        displayName: profiles.displayName,
+        avatarUrl: profiles.avatarUrl,
+      },
+    })
+    .from(topicPosts)
+    .leftJoin(profiles, eq(topicPosts.userId, profiles.id))
+    .where(
+      and(
+        eq(topicPosts.id, postId),
+        eq(topicPosts.topicType, 'square'),
+        eq(topicPosts.topicKey, square)
+      )
+    )
+    .limit(1);
+
+  if (results.length === 0) {
+    return null;
+  }
+
+  return {
+    ...results[0].post,
+    author: results[0].author,
+  };
+}

--- a/apps/web/src/app/[locale]/(public)/topics/squares/_lib/relative-time.test.ts
+++ b/apps/web/src/app/[locale]/(public)/topics/squares/_lib/relative-time.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { formatRelativeTime } from './relative-time';
+
+describe('formatRelativeTime', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-06-15T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const justNowLabel = 'just now';
+
+  describe('just now (< 60 seconds)', () => {
+    it('returns justNowLabel for 0 seconds ago', () => {
+      const date = new Date('2025-06-15T12:00:00Z');
+      expect(formatRelativeTime(date, 'en', justNowLabel)).toBe('just now');
+    });
+
+    it('returns justNowLabel for 30 seconds ago', () => {
+      const date = new Date('2025-06-15T11:59:30Z');
+      expect(formatRelativeTime(date, 'en', justNowLabel)).toBe('just now');
+    });
+
+    it('returns justNowLabel for 59 seconds ago', () => {
+      const date = new Date('2025-06-15T11:59:01Z');
+      expect(formatRelativeTime(date, 'en', justNowLabel)).toBe('just now');
+    });
+  });
+
+  describe('minutes (1-59 minutes)', () => {
+    it('returns minutes for exactly 1 minute ago', () => {
+      const date = new Date('2025-06-15T11:59:00Z');
+      const result = formatRelativeTime(date, 'en', justNowLabel);
+      expect(result).toContain('1');
+      expect(result).toContain('minute');
+    });
+
+    it('returns minutes for 30 minutes ago', () => {
+      const date = new Date('2025-06-15T11:30:00Z');
+      const result = formatRelativeTime(date, 'en', justNowLabel);
+      expect(result).toContain('30');
+      expect(result).toContain('minute');
+    });
+
+    it('returns minutes for 59 minutes ago', () => {
+      const date = new Date('2025-06-15T11:01:00Z');
+      const result = formatRelativeTime(date, 'en', justNowLabel);
+      expect(result).toContain('59');
+      expect(result).toContain('minute');
+    });
+  });
+
+  describe('hours (1-23 hours)', () => {
+    it('returns hours for exactly 1 hour ago', () => {
+      const date = new Date('2025-06-15T11:00:00Z');
+      const result = formatRelativeTime(date, 'en', justNowLabel);
+      expect(result).toContain('1');
+      expect(result).toContain('hour');
+    });
+
+    it('returns hours for 12 hours ago', () => {
+      const date = new Date('2025-06-15T00:00:00Z');
+      const result = formatRelativeTime(date, 'en', justNowLabel);
+      expect(result).toContain('12');
+      expect(result).toContain('hour');
+    });
+
+    it('returns hours for 23 hours ago', () => {
+      const date = new Date('2025-06-14T13:00:00Z');
+      const result = formatRelativeTime(date, 'en', justNowLabel);
+      expect(result).toContain('23');
+      expect(result).toContain('hour');
+    });
+  });
+
+  describe('days (1-29 days)', () => {
+    it('returns days for exactly 1 day ago', () => {
+      const date = new Date('2025-06-14T12:00:00Z');
+      const result = formatRelativeTime(date, 'en', justNowLabel);
+      expect(result).toContain('1');
+      expect(result).toContain('day');
+    });
+
+    it('returns days for 15 days ago', () => {
+      const date = new Date('2025-05-31T12:00:00Z');
+      const result = formatRelativeTime(date, 'en', justNowLabel);
+      expect(result).toContain('15');
+      expect(result).toContain('day');
+    });
+
+    it('returns days for 29 days ago', () => {
+      const date = new Date('2025-05-17T12:00:00Z');
+      const result = formatRelativeTime(date, 'en', justNowLabel);
+      expect(result).toContain('29');
+      expect(result).toContain('day');
+    });
+  });
+
+  describe('months (1-11 months)', () => {
+    it('returns months for 30 days ago (1 month)', () => {
+      const date = new Date('2025-05-16T12:00:00Z');
+      const result = formatRelativeTime(date, 'en', justNowLabel);
+      expect(result).toContain('1');
+      expect(result).toContain('month');
+    });
+
+    it('returns months for ~6 months ago', () => {
+      const date = new Date('2024-12-15T12:00:00Z');
+      const result = formatRelativeTime(date, 'en', justNowLabel);
+      // 182 days / 30 = 6 months
+      expect(result).toContain('6');
+      expect(result).toContain('month');
+    });
+
+    it('returns months for 11 months ago', () => {
+      // 330 days ago => 11 months (330 / 30 = 11)
+      const date = new Date('2024-07-20T12:00:00Z');
+      const result = formatRelativeTime(date, 'en', justNowLabel);
+      expect(result).toContain('11');
+      expect(result).toContain('month');
+    });
+  });
+
+  describe('years (12+ months)', () => {
+    it('returns years for 1 year ago', () => {
+      const date = new Date('2024-06-15T12:00:00Z');
+      const result = formatRelativeTime(date, 'en', justNowLabel);
+      expect(result).toContain('1');
+      expect(result).toContain('year');
+    });
+
+    it('returns years for 2 years ago', () => {
+      const date = new Date('2023-06-15T12:00:00Z');
+      const result = formatRelativeTime(date, 'en', justNowLabel);
+      expect(result).toContain('2');
+      expect(result).toContain('year');
+    });
+  });
+
+  describe('locale support', () => {
+    it('formats in English', () => {
+      const date = new Date('2025-06-15T11:55:00Z');
+      const result = formatRelativeTime(date, 'en', 'just now');
+      expect(result).toContain('5');
+      expect(result).toContain('minute');
+    });
+
+    it('formats in Japanese', () => {
+      const date = new Date('2025-06-15T11:55:00Z');
+      const result = formatRelativeTime(date, 'ja', 'たった今');
+      expect(result).toContain('5');
+      // Japanese uses "分前" for minutes ago
+      expect(result).toMatch(/分/);
+    });
+
+    it('returns the provided justNowLabel for Japanese locale', () => {
+      const date = new Date('2025-06-15T12:00:00Z');
+      expect(formatRelativeTime(date, 'ja', 'たった今')).toBe('たった今');
+    });
+  });
+
+  describe('boundary transitions', () => {
+    it('transitions from justNow to minutes at exactly 60 seconds', () => {
+      const date = new Date('2025-06-15T11:59:00Z');
+      const result = formatRelativeTime(date, 'en', justNowLabel);
+      expect(result).not.toBe('just now');
+      expect(result).toContain('minute');
+    });
+
+    it('transitions from minutes to hours at exactly 60 minutes', () => {
+      const date = new Date('2025-06-15T11:00:00Z');
+      const result = formatRelativeTime(date, 'en', justNowLabel);
+      expect(result).toContain('hour');
+      expect(result).not.toContain('minute');
+    });
+
+    it('transitions from hours to days at exactly 24 hours', () => {
+      const date = new Date('2025-06-14T12:00:00Z');
+      const result = formatRelativeTime(date, 'en', justNowLabel);
+      expect(result).toContain('day');
+      expect(result).not.toContain('hour');
+    });
+
+    it('transitions from days to months at exactly 30 days', () => {
+      const date = new Date('2025-05-16T12:00:00Z');
+      const result = formatRelativeTime(date, 'en', justNowLabel);
+      expect(result).toContain('month');
+      expect(result).not.toContain('day');
+    });
+  });
+});

--- a/apps/web/src/app/[locale]/(public)/topics/squares/_lib/relative-time.ts
+++ b/apps/web/src/app/[locale]/(public)/topics/squares/_lib/relative-time.ts
@@ -1,0 +1,34 @@
+/**
+ * Format a date as relative time string using Intl.RelativeTimeFormat.
+ * Examples: "11 hours ago", "2 days ago" / "11時間前", "2日前"
+ */
+export function formatRelativeTime(date: Date, locale: string, justNowLabel: string): string {
+  const now = Date.now();
+  const diffMs = now - date.getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  const diffMin = Math.floor(diffSec / 60);
+  const diffHour = Math.floor(diffMin / 60);
+  const diffDay = Math.floor(diffHour / 24);
+  const diffMonth = Math.floor(diffDay / 30);
+  const diffYear = Math.floor(diffDay / 365);
+
+  if (diffSec < 60) {
+    return justNowLabel;
+  }
+
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: 'always' });
+
+  if (diffMin < 60) {
+    return rtf.format(-diffMin, 'minute');
+  }
+  if (diffHour < 24) {
+    return rtf.format(-diffHour, 'hour');
+  }
+  if (diffDay < 30) {
+    return rtf.format(-diffDay, 'day');
+  }
+  if (diffMonth < 12) {
+    return rtf.format(-diffMonth, 'month');
+  }
+  return rtf.format(-diffYear, 'year');
+}

--- a/apps/web/src/app/[locale]/(public)/topics/squares/_lib/squares.test.ts
+++ b/apps/web/src/app/[locale]/(public)/topics/squares/_lib/squares.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest';
+
+import { getAllSquares, isLightSquare, isValidSquare } from './squares';
+
+describe('isValidSquare', () => {
+  describe('valid squares', () => {
+    it('should accept all corner squares', () => {
+      expect(isValidSquare('a1')).toBe(true);
+      expect(isValidSquare('a8')).toBe(true);
+      expect(isValidSquare('h1')).toBe(true);
+      expect(isValidSquare('h8')).toBe(true);
+    });
+
+    it('should accept center squares', () => {
+      expect(isValidSquare('e4')).toBe(true);
+      expect(isValidSquare('d5')).toBe(true);
+      expect(isValidSquare('d4')).toBe(true);
+      expect(isValidSquare('e5')).toBe(true);
+    });
+
+    it('should accept all 64 valid squares', () => {
+      const files = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
+      const ranks = ['1', '2', '3', '4', '5', '6', '7', '8'];
+      let count = 0;
+      for (const file of files) {
+        for (const rank of ranks) {
+          expect(isValidSquare(`${file}${rank}`)).toBe(true);
+          count++;
+        }
+      }
+      expect(count).toBe(64);
+    });
+  });
+
+  describe('invalid squares', () => {
+    it('should reject squares with invalid file', () => {
+      expect(isValidSquare('i1')).toBe(false);
+      expect(isValidSquare('z5')).toBe(false);
+    });
+
+    it('should reject squares with invalid rank', () => {
+      expect(isValidSquare('a0')).toBe(false);
+      expect(isValidSquare('a9')).toBe(false);
+      expect(isValidSquare('h0')).toBe(false);
+    });
+
+    it('should reject completely invalid input', () => {
+      expect(isValidSquare('z9')).toBe(false);
+      expect(isValidSquare('i9')).toBe(false);
+    });
+
+    it('should reject reversed order (rank then file)', () => {
+      expect(isValidSquare('1a')).toBe(false);
+      expect(isValidSquare('4e')).toBe(false);
+    });
+
+    it('should reject uppercase files', () => {
+      expect(isValidSquare('A1')).toBe(false);
+      expect(isValidSquare('H8')).toBe(false);
+      expect(isValidSquare('E4')).toBe(false);
+    });
+
+    it('should reject strings that are too short', () => {
+      expect(isValidSquare('')).toBe(false);
+      expect(isValidSquare('a')).toBe(false);
+      expect(isValidSquare('1')).toBe(false);
+    });
+
+    it('should reject strings that are too long', () => {
+      expect(isValidSquare('a1b')).toBe(false);
+      expect(isValidSquare('a1b2')).toBe(false);
+      expect(isValidSquare('aa1')).toBe(false);
+    });
+
+    it('should reject special characters', () => {
+      expect(isValidSquare('a!')).toBe(false);
+      expect(isValidSquare('#1')).toBe(false);
+      expect(isValidSquare('$$')).toBe(false);
+      expect(isValidSquare('a ')).toBe(false);
+      expect(isValidSquare(' 1')).toBe(false);
+    });
+
+    it('should reject double letters and double digits', () => {
+      expect(isValidSquare('aa')).toBe(false);
+      expect(isValidSquare('11')).toBe(false);
+      expect(isValidSquare('hh')).toBe(false);
+      expect(isValidSquare('88')).toBe(false);
+    });
+  });
+});
+
+describe('getAllSquares', () => {
+  it('should return exactly 64 squares', () => {
+    const squares = getAllSquares();
+    expect(squares).toHaveLength(64);
+  });
+
+  it('should return all unique squares', () => {
+    const squares = getAllSquares();
+    const unique = new Set(squares);
+    expect(unique.size).toBe(64);
+  });
+
+  it('should contain all valid squares', () => {
+    const squares = getAllSquares();
+    const files = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
+    const ranks = ['1', '2', '3', '4', '5', '6', '7', '8'];
+    for (const file of files) {
+      for (const rank of ranks) {
+        expect(squares).toContain(`${file}${rank}`);
+      }
+    }
+  });
+
+  it('should return squares ordered by rank descending (8 to 1), then file ascending (a to h)', () => {
+    const squares = getAllSquares();
+    // First square should be a8 (rank 8, file a)
+    expect(squares[0]).toBe('a8');
+    // Second should be b8
+    expect(squares[1]).toBe('b8');
+    // Last should be h1
+    expect(squares[63]).toBe('h1');
+    // First of rank 1 should be at index 56
+    expect(squares[56]).toBe('a1');
+  });
+});
+
+describe('isLightSquare', () => {
+  it('should identify a1 as dark (bottom-left is always dark)', () => {
+    expect(isLightSquare('a1')).toBe(false);
+  });
+
+  it('should identify h1 as light', () => {
+    expect(isLightSquare('h1')).toBe(true);
+  });
+
+  it('should identify a8 as light', () => {
+    expect(isLightSquare('a8')).toBe(true);
+  });
+
+  it('should identify h8 as dark', () => {
+    expect(isLightSquare('h8')).toBe(false);
+  });
+
+  it('should alternate correctly along a rank', () => {
+    // Rank 1: a1=dark, b1=light, c1=dark, d1=light, ...
+    expect(isLightSquare('a1')).toBe(false);
+    expect(isLightSquare('b1')).toBe(true);
+    expect(isLightSquare('c1')).toBe(false);
+    expect(isLightSquare('d1')).toBe(true);
+    expect(isLightSquare('e1')).toBe(false);
+    expect(isLightSquare('f1')).toBe(true);
+    expect(isLightSquare('g1')).toBe(false);
+    expect(isLightSquare('h1')).toBe(true);
+  });
+
+  it('should alternate correctly along a file', () => {
+    // File a: a1=dark, a2=light, a3=dark, a4=light, ...
+    expect(isLightSquare('a1')).toBe(false);
+    expect(isLightSquare('a2')).toBe(true);
+    expect(isLightSquare('a3')).toBe(false);
+    expect(isLightSquare('a4')).toBe(true);
+  });
+
+  it('should have exactly 32 light squares and 32 dark squares', () => {
+    const allSquares = getAllSquares();
+    const lightCount = allSquares.filter((sq) => isLightSquare(sq)).length;
+    const darkCount = allSquares.filter((sq) => !isLightSquare(sq)).length;
+    expect(lightCount).toBe(32);
+    expect(darkCount).toBe(32);
+  });
+});

--- a/apps/web/src/app/[locale]/(public)/topics/squares/_lib/squares.ts
+++ b/apps/web/src/app/[locale]/(public)/topics/squares/_lib/squares.ts
@@ -1,0 +1,32 @@
+const FILES = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'] as const;
+const RANKS = ['1', '2', '3', '4', '5', '6', '7', '8'] as const;
+
+export type File = (typeof FILES)[number];
+export type Rank = (typeof RANKS)[number];
+export type Square = `${File}${Rank}`;
+
+export const VALID_FILES = FILES;
+export const VALID_RANKS = RANKS;
+
+export function isValidSquare(value: string): value is Square {
+  if (value.length !== 2) return false;
+  const file = value[0];
+  const rank = value[1];
+  return (FILES as readonly string[]).includes(file) && (RANKS as readonly string[]).includes(rank);
+}
+
+export function getAllSquares(): Square[] {
+  const squares: Square[] = [];
+  for (const rank of [...RANKS].reverse()) {
+    for (const file of FILES) {
+      squares.push(`${file}${rank}` as Square);
+    }
+  }
+  return squares;
+}
+
+export function isLightSquare(square: Square): boolean {
+  const fileIndex = FILES.indexOf(square[0] as File);
+  const rankIndex = RANKS.indexOf(square[1] as Rank);
+  return (fileIndex + rankIndex) % 2 === 1;
+}

--- a/apps/web/src/app/[locale]/(public)/topics/squares/page.tsx
+++ b/apps/web/src/app/[locale]/(public)/topics/squares/page.tsx
@@ -1,0 +1,56 @@
+import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+
+import {
+  Breadcrumb,
+  Divider,
+  PageDescription,
+  PagePanel,
+  PageTitle,
+} from '@/app/[locale]/_components';
+import { generateCanonicalMetadata } from '@/app/[locale]/_lib/metadata';
+import type { Locale } from '@/app/[locale]/_lib/types';
+
+import { SquareBoard } from './_components';
+import { getSquarePostCounts } from './_lib/queries';
+
+type Props = {
+  params: Promise<{ locale: Locale }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'metadata.topicsSquares' });
+
+  return {
+    ...generateCanonicalMetadata({ locale, path: 'topics/squares' }),
+    title: t('title'),
+    description: t('description'),
+  };
+}
+
+export default async function SquaresPage({ params }: Props) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'topics' });
+
+  const postCounts = await getSquarePostCounts();
+
+  return (
+    <div className="space-y-8">
+      <PageTitle>{t('squares.title')}</PageTitle>
+
+      <PageDescription>{t('squares.description')}</PageDescription>
+
+      <PagePanel>
+        <SquareBoard locale={locale} postCounts={postCounts} />
+
+        <Divider />
+
+        <Breadcrumb
+          items={[{ label: t('title'), href: '/topics' }, { label: t('squares.title') }]}
+          locale={locale}
+        />
+      </PagePanel>
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -1,8 +1,10 @@
 import type { Metadata } from 'next';
 import { getMessages, getTranslations } from 'next-intl/server';
 import { Inter } from 'next/font/google';
+import { notFound } from 'next/navigation';
 
 import { AUTHOR_NAME, COOKIEYES_ID, GA_MEASUREMENT_ID, SITE_NAME, SITE_URL } from '@/config';
+import { routing } from '@/i18n/routing';
 import { generateThemeCSS } from '@blindfold-chess/ui';
 import { GoogleAnalytics } from '@next/third-parties/google';
 
@@ -97,6 +99,12 @@ export default async function Layout({
   params: Promise<{ locale: string }>;
 }) {
   const { locale } = await params;
+
+  // Ensure that the incoming `locale` is valid
+  if (!(routing.locales as readonly string[]).includes(locale)) {
+    notFound();
+  }
+
   const allMessages = await getMessages({ locale });
 
   // Namespaces used only by Server Components (via getTranslations()), not by

--- a/apps/web/src/app/_components/TextInput.tsx
+++ b/apps/web/src/app/_components/TextInput.tsx
@@ -1,0 +1,13 @@
+import type { InputHTMLAttributes } from 'react';
+
+type Props = InputHTMLAttributes<HTMLInputElement>;
+
+export function TextInput({ className = '', type = 'text', ...props }: Props) {
+  return (
+    <input
+      type={type}
+      className={`w-full px-4 py-3 bg-card border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent ${className}`.trim()}
+      {...props}
+    />
+  );
+}

--- a/apps/web/src/app/_components/Textarea.tsx
+++ b/apps/web/src/app/_components/Textarea.tsx
@@ -1,12 +1,57 @@
+'use client';
+
+import { useState } from 'react';
 import type { TextareaHTMLAttributes } from 'react';
 
-type Props = TextareaHTMLAttributes<HTMLTextAreaElement>;
+type Props = TextareaHTMLAttributes<HTMLTextAreaElement> & {
+  /** Show character counter. Defaults to true when maxLength is set. */
+  showCount?: boolean;
+};
 
-export function Textarea({ className = '', ...props }: Props) {
+export function Textarea({
+  className = '',
+  maxLength,
+  showCount,
+  defaultValue,
+  value,
+  onChange,
+  ...props
+}: Props) {
+  const [internalLength, setInternalLength] = useState(
+    () => String(value ?? defaultValue ?? '').length
+  );
+
+  const shouldShowCount = showCount ?? maxLength != null;
+  const currentLength = value != null ? String(value).length : internalLength;
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setInternalLength(e.target.value.length);
+    onChange?.(e);
+  };
+
+  const ratio = maxLength ? currentLength / maxLength : 0;
+  const counterColor =
+    ratio >= 1
+      ? 'text-destructive'
+      : ratio >= 0.9
+        ? 'text-warning dark:text-yellow-400'
+        : 'text-muted-foreground';
+
   return (
-    <textarea
-      className={`w-full px-4 py-3 bg-card border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent resize-y ${className}`.trim()}
-      {...props}
-    />
+    <div>
+      <textarea
+        className={`w-full px-4 py-3 bg-card border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent resize-y ${className}`.trim()}
+        maxLength={maxLength}
+        value={value}
+        defaultValue={defaultValue}
+        onChange={handleChange}
+        {...props}
+      />
+      {shouldShowCount && maxLength && (
+        <p className={`mt-1 text-xs text-right ${counterColor}`}>
+          {currentLength.toLocaleString()} / {maxLength.toLocaleString()}
+        </p>
+      )}
+    </div>
   );
 }

--- a/apps/web/src/app/_components/Textarea.tsx
+++ b/apps/web/src/app/_components/Textarea.tsx
@@ -1,0 +1,12 @@
+import type { TextareaHTMLAttributes } from 'react';
+
+type Props = TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+export function Textarea({ className = '', ...props }: Props) {
+  return (
+    <textarea
+      className={`w-full px-4 py-3 bg-card border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent resize-y ${className}`.trim()}
+      {...props}
+    />
+  );
+}

--- a/apps/web/src/app/_components/index.ts
+++ b/apps/web/src/app/_components/index.ts
@@ -1,4 +1,5 @@
 export { Button } from './Button';
+export { TextInput } from './TextInput';
 export { Textarea } from './Textarea';
 export * from './BoardOverlay';
 export { BoardLayout } from './chess/BoardLayout';

--- a/apps/web/src/app/_components/index.ts
+++ b/apps/web/src/app/_components/index.ts
@@ -1,4 +1,5 @@
 export { Button } from './Button';
+export { Textarea } from './Textarea';
 export * from './BoardOverlay';
 export { BoardLayout } from './chess/BoardLayout';
 export type { SquareRenderInfo } from './chess/BoardLayout';

--- a/apps/web/src/lib/db/schema.ts
+++ b/apps/web/src/lib/db/schema.ts
@@ -169,3 +169,83 @@ export const userRoles = pgTable(
 
 export type UserRole = typeof userRoles.$inferSelect;
 export type NewUserRole = typeof userRoles.$inferInsert;
+
+/**
+ * Topic Posts — UGC (User Generated Content) for chess concepts.
+ *
+ * @description
+ * A polymorphic table that stores user opinions/impressions about various chess
+ * concepts (squares, diagonals, pawn structures, etc.).
+ *
+ * @design Polymorphic topicType + topicKey pattern
+ *
+ * Instead of creating separate tables per topic type (square_opinions,
+ * diagonal_opinions, ...), this single table uses a discriminator pair:
+ * - `topicType`: the category of the topic (e.g., 'square', 'diagonal', 'pawn-structure')
+ * - `topicKey`: the identifier within that category (e.g., 'e4', 'a1h8', 'french')
+ *
+ * This avoids schema changes when adding new topic types. Validation of topicKey
+ * values is handled at the application layer since the format differs per topicType.
+ *
+ * @design topicKey must always be short and URL-safe
+ *
+ * topicKey appears in URLs (e.g., /topics/squares/e4), so it must be concise and
+ * URL-safe. For fixed/finite topics (squares: a1-h8, diagonals), the natural
+ * identifier is used directly. For open-ended topics (pawn structures), a separate
+ * master table provides human-readable slugs that serve as topicKey values,
+ * keeping complex data (like FEN strings) out of the key/URL.
+ *
+ * @design topicType is varchar, not pgEnum
+ *
+ * New topic types (diagonals, pawn structures, etc.) will be added incrementally.
+ * Using varchar avoids requiring an ALTER TYPE migration for each new type.
+ *
+ * @design No locale column — UGC is language-agnostic
+ *
+ * Unlike editorial content (posts, glossary), user-generated opinions are displayed
+ * regardless of language. The [locale] route segment only affects UI chrome (labels,
+ * buttons), not content filtering. This follows the pattern of major UGC platforms
+ * (X, Reddit, Instagram) and avoids fragmenting a niche community by language.
+ *
+ * @design No title column
+ *
+ * Posts are short-to-medium opinions (similar to X posts or Reddit comments), not
+ * titled articles. Omitting title: (1) lowers the posting friction, (2) avoids a
+ * NULL-heavy column since replies (via parentId self-reference) never need titles,
+ * and (3) eliminates the need for two different card layouts in list views.
+ * Content preview (truncated first line) is used for list display instead.
+ *
+ * @design parentId for Reddit-style threaded replies (future scope)
+ *
+ * Top-level posts have parentId = null. Replies point to their parent's id.
+ * The column exists in the initial schema to solidify the table structure, but
+ * reply functionality is not implemented in the initial scope.
+ *
+ * @design FKs managed in custom SQL
+ *
+ * userId → auth.users and parentId → topic_posts self-reference are defined in
+ * Supabase-side SQL (not Drizzle references), following the same pattern as
+ * profiles.id. This is because auth.users lives in a separate Supabase-managed
+ * schema that Drizzle does not control.
+ */
+export const topicPosts = pgTable(
+  'topic_posts',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    userId: uuid('user_id').notNull(), // references auth.users — FK defined in custom SQL
+    topicType: varchar('topic_type', { length: 50 }).notNull(),
+    topicKey: varchar('topic_key', { length: 50 }).notNull(),
+    parentId: uuid('parent_id'), // self-referencing FK defined in custom SQL
+    content: text('content').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    index('idx_topic_posts_topic').on(table.topicType, table.topicKey),
+    index('idx_topic_posts_user').on(table.userId),
+    index('idx_topic_posts_parent').on(table.parentId),
+  ]
+);
+
+export type TopicPost = typeof topicPosts.$inferSelect;
+export type NewTopicPost = typeof topicPosts.$inferInsert;

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -56,6 +56,26 @@
     "deleteAccount": {
       "title": "Delete Account",
       "description": "Delete your Blindfold Chess account"
+    },
+    "topics": {
+      "title": "Topics",
+      "description": "Discuss and share insights about chess squares, positions, and strategies"
+    },
+    "topicsSquares": {
+      "title": "Square Topics",
+      "description": "Browse discussions about individual chess squares"
+    },
+    "topicsSquare": {
+      "title": "Square {square}",
+      "description": "Discussions and insights about the {square} square in chess"
+    },
+    "topicsSquareNewPost": {
+      "title": "New Post - {square}",
+      "description": "Create a new post about the {square} square"
+    },
+    "topicsSquarePost": {
+      "title": "Post about {square}",
+      "description": "A discussion post about the {square} square in chess"
     }
   },
   "Header": {
@@ -1834,5 +1854,41 @@
     "chessAccounts": "Chess Accounts",
     "bio": "About",
     "emptyProfile": "This user hasn't added any profile information yet."
+  },
+  "topics": {
+    "title": "Topics",
+    "description": "Discuss and share insights about chess squares, positions, and strategies",
+    "categories": {
+      "squares": {
+        "title": "Squares",
+        "description": "Discussion about individual chess squares"
+      }
+    },
+    "squares": {
+      "title": "Squares",
+      "description": "Select a square to view and share discussions",
+      "postCount": "{count, plural, one {# post} other {# posts}}",
+      "noPosts": "No posts yet. Be the first to share your thoughts!",
+      "newPost": "New Post",
+      "backToSquares": "Back to Squares",
+      "backToTopics": "Back to Topics",
+      "postedBy": "by {author}",
+      "postedAt": "Posted {date}",
+      "readMore": "Read more",
+      "postDetail": {
+        "backToSquare": "Back to {square}"
+      },
+      "newPostForm": {
+        "title": "New Post about {square}",
+        "contentLabel": "Content",
+        "contentPlaceholder": "Share your thoughts about this square...",
+        "submit": "Post",
+        "submitting": "Posting...",
+        "contentRequired": "Please enter some content",
+        "contentTooLong": "Content must be 5000 characters or less",
+        "error": "An error occurred. Please try again.",
+        "signInRequired": "Please sign in to create a post"
+      }
+    }
   }
 }

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -1877,7 +1877,8 @@
       "postedAt": "Posted {date}",
       "readMore": "Read more",
       "postDetail": {
-        "backToSquare": "Back to {square}"
+        "backToSquare": "Back to {square}",
+        "authorView": "{author}'s thoughts on {square}"
       },
       "newPostForm": {
         "title": "New Post about {square}",

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -1891,6 +1891,9 @@
         "error": "An error occurred. Please try again.",
         "signInRequired": "Please sign in to create a post"
       },
+      "replyCount": "{count, plural, one {# reply} other {# replies}}",
+      "newReply": "New Reply {time}",
+      "justNow": "just now",
       "replies": {
         "title": "Replies",
         "count": "{count, plural, one {# reply} other {# replies}}",

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -1809,6 +1809,7 @@
     "avatarInvalidType": "Please select a JPEG, PNG, or WebP image.",
     "avatarTooLarge": "Image must be 2MB or less.",
     "avatarUploadFailed": "Failed to upload image. Please try again.",
+    "avatarUploaded": "Profile picture updated",
     "submit": "Save",
     "submitting": "Saving...",
     "error": "An error occurred. Please try again."

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -1890,6 +1890,20 @@
         "contentTooLong": "Content must be 5000 characters or less",
         "error": "An error occurred. Please try again.",
         "signInRequired": "Please sign in to create a post"
+      },
+      "replies": {
+        "title": "Replies",
+        "count": "{count, plural, one {# reply} other {# replies}}",
+        "noReplies": "No replies yet. Be the first to reply!",
+        "contentLabel": "Your reply",
+        "contentPlaceholder": "Share your thoughts...",
+        "submit": "Reply",
+        "submitting": "Replying...",
+        "contentRequired": "Please enter some content",
+        "contentTooLong": "Content must be 5000 characters or less",
+        "error": "An error occurred. Please try again.",
+        "signInRequired": "Please sign in to reply",
+        "loginToReply": "Sign in to reply"
       }
     }
   }

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -1867,6 +1867,7 @@
     "squares": {
       "title": "Squares",
       "description": "Select a square to view and share discussions",
+      "pageTitle": "Impressions & Insights",
       "postCount": "{count, plural, one {# post} other {# posts}}",
       "noPosts": "No posts yet. Be the first to share your thoughts!",
       "newPost": "New Post",

--- a/apps/web/src/messages/ja.json
+++ b/apps/web/src/messages/ja.json
@@ -1810,6 +1810,7 @@
     "avatarInvalidType": "JPEG、PNG、またはWebP画像を選択してください。",
     "avatarTooLarge": "画像は2MB以下にしてください。",
     "avatarUploadFailed": "画像のアップロードに失敗しました。もう一度お試しください。",
+    "avatarUploaded": "プロフィール画像を更新しました",
     "submit": "保存",
     "submitting": "保存中...",
     "error": "エラーが発生しました。もう一度お試しください。"

--- a/apps/web/src/messages/ja.json
+++ b/apps/web/src/messages/ja.json
@@ -56,6 +56,26 @@
     "deleteAccount": {
       "title": "退会",
       "description": "Blindfold Chess のアカウントを削除します"
+    },
+    "topics": {
+      "title": "トピック",
+      "description": "チェスのマス目やポジション、戦略について議論・共有しましょう"
+    },
+    "topicsSquares": {
+      "title": "マス目トピック",
+      "description": "個々のチェスのマス目についての議論を閲覧"
+    },
+    "topicsSquare": {
+      "title": "マス目 {square}",
+      "description": "チェスの{square}マスに関する議論と考察"
+    },
+    "topicsSquareNewPost": {
+      "title": "新規投稿 - {square}",
+      "description": "{square}マスについて新しい投稿を作成"
+    },
+    "topicsSquarePost": {
+      "title": "{square}についての投稿",
+      "description": "チェスの{square}マスに関する議論の投稿"
     }
   },
   "Header": {
@@ -1835,5 +1855,41 @@
     "chessAccounts": "チェスアカウント",
     "bio": "自己紹介",
     "emptyProfile": "このユーザーはまだプロフィール情報を追加していません。"
+  },
+  "topics": {
+    "title": "トピック",
+    "description": "チェスのマス目やポジション、戦略について議論・共有しましょう",
+    "categories": {
+      "squares": {
+        "title": "マス目",
+        "description": "個々のチェスのマス目についての議論"
+      }
+    },
+    "squares": {
+      "title": "マス目",
+      "description": "マス目を選んで議論を閲覧・共有しましょう",
+      "postCount": "{count}件の投稿",
+      "noPosts": "まだ投稿がありません。最初の投稿をしてみましょう！",
+      "newPost": "新規投稿",
+      "backToSquares": "マス目一覧に戻る",
+      "backToTopics": "トピックに戻る",
+      "postedBy": "{author}",
+      "postedAt": "{date}に投稿",
+      "readMore": "続きを読む",
+      "postDetail": {
+        "backToSquare": "{square}に戻る"
+      },
+      "newPostForm": {
+        "title": "{square}について投稿",
+        "contentLabel": "内容",
+        "contentPlaceholder": "このマス目について思うことを共有しましょう...",
+        "submit": "投稿する",
+        "submitting": "投稿中...",
+        "contentRequired": "内容を入力してください",
+        "contentTooLong": "内容は5000文字以内にしてください",
+        "error": "エラーが発生しました。もう一度お試しください。",
+        "signInRequired": "投稿するにはサインインが必要です"
+      }
+    }
   }
 }

--- a/apps/web/src/messages/ja.json
+++ b/apps/web/src/messages/ja.json
@@ -1891,6 +1891,20 @@
         "contentTooLong": "内容は5000文字以内にしてください",
         "error": "エラーが発生しました。もう一度お試しください。",
         "signInRequired": "投稿するにはサインインが必要です"
+      },
+      "replies": {
+        "title": "返信",
+        "count": "{count}件の返信",
+        "noReplies": "まだ返信がありません。最初の返信をしてみましょう！",
+        "contentLabel": "返信内容",
+        "contentPlaceholder": "あなたの考えを共有しましょう...",
+        "submit": "返信する",
+        "submitting": "返信中...",
+        "contentRequired": "内容を入力してください",
+        "contentTooLong": "内容は5000文字以内にしてください",
+        "error": "エラーが発生しました。もう一度お試しください。",
+        "signInRequired": "返信するにはサインインが必要です",
+        "loginToReply": "サインインして返信する"
       }
     }
   }

--- a/apps/web/src/messages/ja.json
+++ b/apps/web/src/messages/ja.json
@@ -1892,6 +1892,9 @@
         "error": "エラーが発生しました。もう一度お試しください。",
         "signInRequired": "投稿するにはサインインが必要です"
       },
+      "replyCount": "{count}件の返信",
+      "newReply": "新しい返信 {time}",
+      "justNow": "たった今",
       "replies": {
         "title": "返信",
         "count": "{count}件の返信",

--- a/apps/web/src/messages/ja.json
+++ b/apps/web/src/messages/ja.json
@@ -1868,6 +1868,7 @@
     "squares": {
       "title": "マス目",
       "description": "マス目を選んで議論を閲覧・共有しましょう",
+      "pageTitle": "みんなが考えるマスの特徴や印象",
       "postCount": "{count}件の投稿",
       "noPosts": "まだ投稿がありません。最初の投稿をしてみましょう！",
       "newPost": "新規投稿",

--- a/apps/web/src/messages/ja.json
+++ b/apps/web/src/messages/ja.json
@@ -1878,7 +1878,8 @@
       "postedAt": "{date}に投稿",
       "readMore": "続きを読む",
       "postDetail": {
-        "backToSquare": "{square}に戻る"
+        "backToSquare": "{square}に戻る",
+        "authorView": "{author}の{square}に対する見解"
       },
       "newPostForm": {
         "title": "{square}について投稿",


### PR DESCRIPTION
## Description

This PR fixes #11 by properly validating the locale in `src/app/[locale]/layout.tsx`.

Currently, unsupported locales (e.g. `/cn`) silently fall back to the english default. By explicitly checking if the requested locale is in the supported `routing.locales` list and calling `notFound()`, we ensure a 404 response is cleanly issued instead.

## Testing
- Unit tests pass. 
- Local test confirms `/cn/practice` returns `404`.
- Local test confirms `/en/practice` returns `200`.