### PR TITLE
feat(web): env-switchable pooler mode for the connection black-hole experiment

### DIFF
--- a/apps/web/src/lib/db/index.ts
+++ b/apps/web/src/lib/db/index.ts
@@ -4,6 +4,7 @@ import { drizzle } from 'drizzle-orm/postgres-js';
 import type { Sql } from 'postgres';
 import postgres from 'postgres';
 
+import { derivePoolerMode } from './pooler-mode';
 import {
   type DeadlineRetry,
   setDeadlineRetry,
@@ -13,13 +14,29 @@ import {
 } from './query-deadline';
 import * as schema from './schema';
 
+// DB_RUNTIME_URL: Runtime-only override, wins over the integration-managed
+//   POSTGRES_URL. Exists so the pooler mode can be switched (e.g. to the
+//   Supavisor session pooler on port 5432) from the Vercel dashboard without
+//   touching integration-managed variables. Build-time scripts (migrate/seed,
+//   drizzle-kit) do NOT read it — they prefer POSTGRES_URL_NON_POOLING — so
+//   setting it never changes what migrations run against.
 // POSTGRES_URL: Set by Vercel Marketplace Supabase integration
 // DATABASE_URL: For manual configuration
 // Default: Supabase local PostgreSQL for development
 const connectionString =
+  process.env.DB_RUNTIME_URL ||
   process.env.POSTGRES_URL ||
   process.env.DATABASE_URL ||
   'postgresql://postgres:postgres@127.0.0.1:54322/postgres';
+
+/**
+ * Stamped on every server-side Sentry event so black-hole incident rates
+ * (`db-pool-rebuilt`, `db-deadline-retry`, `QueryDeadlineError`) can be
+ * compared across pooler modes — the 2026-08 investigation's next experiment
+ * is exactly that comparison (transaction pooler vs session pooler).
+ */
+const poolerMode = derivePoolerMode(connectionString);
+Sentry.getGlobalScope().setTag('db.pooler_mode', poolerMode);
 
 // Reuse the same postgres client across reloads/invocations.
 // - In development: avoids a new pool per HMR hot-reload (would exhaust
@@ -54,8 +71,17 @@ const IDLE_TIMEOUT_SECONDS = 20;
 
 function createPooledClient(): ReturnType<typeof postgres> {
   return postgres(connectionString, {
-    prepare: false, // required for Supabase transaction-mode pooler (port 6543)
-    max: 10, // postgres.js default, made explicit — shared budget under Fluid Compute
+    // Required for the transaction-mode pooler (port 6543). Kept false in
+    // session mode too, deliberately: the pooler experiment must change one
+    // variable at a time. Revisit as a perf follow-up if session mode sticks.
+    prepare: false,
+    // Shared budget under Fluid Compute. In session mode each client
+    // connection pins a dedicated Postgres backend for its lifetime, and the
+    // per-tenant backend budget (dashboard "Pool Size") is shared across ALL
+    // concurrently-warm instances — so the per-instance cap is halved there.
+    // Check the dashboard budget covers max × expected warm instances before
+    // switching modes.
+    max: poolerMode === 'session' ? 5 : 10,
     idle_timeout: IDLE_TIMEOUT_SECONDS, // release idle connections back to the pooler
     max_lifetime: 60 * 30, // seconds — recycle long-lived connections
     connect_timeout: 10, // seconds — fail fast instead of the 30s default

--- a/apps/web/src/lib/db/pooler-mode.test.ts
+++ b/apps/web/src/lib/db/pooler-mode.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { derivePoolerMode } from './pooler-mode';
+
+describe('derivePoolerMode', () => {
+  it('classifies the Supavisor transaction pooler by its port', () => {
+    expect(
+      derivePoolerMode(
+        'postgresql://postgres.ref:pw@aws-0-us-east-1.pooler.supabase.com:6543/postgres'
+      )
+    ).toBe('transaction');
+  });
+
+  it('classifies the Supavisor session pooler by host on the Postgres port', () => {
+    expect(
+      derivePoolerMode(
+        'postgresql://postgres.ref:pw@aws-0-us-east-1.pooler.supabase.com:5432/postgres'
+      )
+    ).toBe('session');
+  });
+
+  it('classifies a non-pooler remote host as direct', () => {
+    expect(derivePoolerMode('postgresql://postgres:pw@db.abcdefgh.supabase.co:5432/postgres')).toBe(
+      'direct'
+    );
+  });
+
+  it('classifies loopback development databases as local regardless of port', () => {
+    expect(derivePoolerMode('postgresql://postgres:postgres@127.0.0.1:54322/postgres')).toBe(
+      'local'
+    );
+    expect(derivePoolerMode('postgresql://postgres:postgres@localhost:5432/postgres')).toBe(
+      'local'
+    );
+  });
+
+  it('returns unknown for an unparseable string', () => {
+    expect(derivePoolerMode('not a url')).toBe('unknown');
+  });
+});

--- a/apps/web/src/lib/db/pooler-mode.ts
+++ b/apps/web/src/lib/db/pooler-mode.ts
@@ -1,0 +1,34 @@
+/**
+ * How the app's connection string reaches Postgres. Derived from the URL so
+ * every Sentry event can carry it as a tag (`db.pooler_mode`) — the black-hole
+ * investigation (see the navigation-stall entry in CLAUDE.md's Known Issues)
+ * needs incident rates compared across pooler modes, and a tag derived at the
+ * pool module beats remembering which deploy used which URL.
+ *
+ * - `transaction` — Supavisor transaction mode (port 6543): a backend is
+ *   assigned per statement. The mode in production while the black hole was
+ *   observed.
+ * - `session` — Supavisor session mode (pooler host, port 5432): a backend is
+ *   pinned to the client connection for its lifetime, bypassing per-statement
+ *   backend assignment.
+ * - `direct` — no pooler in the path (db.<ref>.supabase.co or any non-pooler
+ *   remote host).
+ * - `local` — loopback development database.
+ * - `unknown` — the URL did not parse; the pool will fail on its own terms.
+ */
+export type PoolerMode = 'transaction' | 'session' | 'direct' | 'local' | 'unknown';
+
+const LOCAL_HOSTS = new Set(['127.0.0.1', 'localhost', '::1']);
+
+export function derivePoolerMode(connectionString: string): PoolerMode {
+  let url: URL;
+  try {
+    url = new URL(connectionString);
+  } catch {
+    return 'unknown';
+  }
+  if (LOCAL_HOSTS.has(url.hostname)) return 'local';
+  if (url.port === '6543') return 'transaction';
+  if (url.hostname.includes('pooler.')) return 'session';
+  return 'direct';
+}

--- a/turbo.json
+++ b/turbo.json
@@ -17,7 +17,7 @@
     "build": {
       "dependsOn": ["^build"],
       "outputs": [".next/**", "!.next/cache/**"],
-      "env": ["POSTGRES_URL"],
+      "env": ["POSTGRES_URL", "DB_RUNTIME_URL"],
       "passThroughEnv": [
         "DATABASE_URL",
         "SUPABASE_SERVICE_ROLE_KEY",


### PR DESCRIPTION
## Problem

Production has an ongoing incident where **sub-millisecond SELECTs go silent for 10+ seconds on established connections** ("connection black hole" — see the navigation-stall entry in `apps/web/CLAUDE.md` Known Issues). Key established facts:

- The event loop, instance freezes, and the DB itself have all been ruled out: deadline timers fire on schedule (`overshoot ≈ 0`), never-frozen instances reproduce it, `pg_stat_activity` shows the backend idle in `ClientRead`, and `connect_timeout` never fires — TCP+TLS+auth succeed, then the query vanishes.
- The transparent SELECT retry (`db-deadline-retry`) proves it decisively and repeatedly: the same query that was silent for 10s on the original connection answers in **5–182ms on a fresh connection**. User impact is therefore downgraded from error pages to ~10.5s-slow pages, but the black hole itself continues at a steady ~0.5–1 episode/hour (unchanged through 2026-08-07, across major refactors and a Free→Pro upgrade).
- Two full-outage windows (original + retry both black-holed) occurred on 2026-08-05 16:19:55Z and 2026-08-07 03:19:27Z, both on `/mypage/subscription`.

The prime suspect is external: **Supavisor transaction-mode pooler (port 6543) backend assignment, or the Vercel↔Supabase network path**.

## What this PR does

Prepares a controlled experiment: run the app on the **Supavisor session pooler (port 5432)** and compare incident rates across pooler modes. Everything is inert until an env var is set — merging and deploying this changes nothing by itself.

- **`DB_RUNTIME_URL`** (new, optional): runtime-only connection-string override that wins over the integration-managed `POSTGRES_URL`. Build-time scripts (`migrate`/`seed`/`drizzle-kit`) prefer `POSTGRES_URL_NON_POOLING` and never read it, so migrations always target the same DB regardless of the experiment.
- **`derivePoolerMode()`** (`apps/web/src/lib/db/pooler-mode.ts`): classifies the connection URL as `transaction | session | direct | local | unknown` and stamps it on **every server-side Sentry event** as the `db.pooler_mode` tag — so `db-pool-rebuilt`, `db-deadline-retry`, and `QueryDeadlineError` rates can be filtered and compared per mode directly in Sentry.
- **Session mode halves the per-instance pool cap (`max: 10 → 5`)**: in session mode each client connection pins a dedicated Postgres backend for its lifetime, and the per-tenant backend budget (dashboard "Pool Size") is shared across all warm Fluid Compute instances.
- **`prepare: false` is kept in both modes deliberately** — the experiment must change one variable at a time. Enabling prepared statements in session mode is a possible perf follow-up, not part of this.

All existing instrumentation and self-healing (query deadline, transparent SELECT retry, pool rebuild, pool-drain keepalive) is intentionally untouched — it is the measurement apparatus.

## Deploy / experiment runbook

1. **Pre-check**: in the Supabase dashboard (Database → Connection pooling), confirm the session pooler Pool Size covers `5 × expected warm instances`.
2. Merge & deploy this PR (no behavior change yet).
3. In Vercel, set `DB_RUNTIME_URL` to the session pooler URL — `postgresql://postgres.<ref>:<password>@aws-0-us-east-1.pooler.supabase.com:5432/postgres` — and redeploy.
4. Confirm in Sentry that new events carry `db.pooler_mode: session`.
5. **Observe 24–48h** against the baseline (~15 episodes/day, 1 per 1–3 hours):
   - `db-deadline-retry` / `db-pool-rebuilt` drop to ≈0 → **the transaction pooler's backend assignment is the culprit**; stay on session mode and attach the finding to the Supabase support ticket.
   - Same rate continues → **pooler mode is innocent**; the problem is the network path or the tenant as a whole — decisive evidence for the support ticket.
6. **Rollback**: delete `DB_RUNTIME_URL` in Vercel and redeploy.

## Verification

- `pnpm typecheck` / `pnpm lint` clean
- All 355 db-layer unit tests pass, including 5 new tests for `derivePoolerMode()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)